### PR TITLE
feat: COMPONENT_MANIFEST spec v0

### DIFF
--- a/docs/COMPONENT_MANIFEST_SPEC.md
+++ b/docs/COMPONENT_MANIFEST_SPEC.md
@@ -1,0 +1,197 @@
+# COMPONENT_MANIFEST Spec v0.1
+
+> A machine-readable description of a UI component, designed to give AI coding assistants the context they need to generate correct, on-brand code.
+
+---
+
+## Motivation
+
+AI tools like Claude, Cursor, and Copilot generate UI code from natural language. Without structured context, they guess at prop names, invent variants that don't exist, and ignore design intent. `COMPONENT_MANIFEST` solves this by attaching a rich, structured descriptor to every component — consumed directly by an MCP server.
+
+---
+
+## Structure
+
+```ts
+interface ComponentManifest {
+  id:               string;               // kebab-case unique identifier
+  name:             string;               // display name
+  tier:             ComponentTier;        // atom | molecule | block | flow | overlay
+  domain:           string;               // "neutral" or product domain
+  description:      string;               // one-sentence summary
+  props:            PropDescriptor[];     // full prop API
+  usageExamples:    UsageExample[];       // copy-paste code snippets
+  compositionGraph: CompositionNode[];    // sub-components (empty for atoms)
+  designIntent:     string;               // the "why" behind visual/interaction decisions
+  accessibility?:   AccessibilityDescriptor;
+  specVersion:      string;               // "MAJOR.MINOR"
+}
+```
+
+---
+
+## Fields
+
+### `id`
+Kebab-case unique identifier. Used by the MCP server for lookups.
+```
+"button" | "form-field" | "data-table"
+```
+
+### `name`
+Display name shown in documentation and tooling.
+
+### `tier`
+The level of the component in the design system hierarchy:
+
+| Tier | Description | Examples |
+|---|---|---|
+| `atom` | Indivisible primitive | Button, Input, Badge |
+| `molecule` | Composed from atoms | FormField, Card, Alert |
+| `block` | Page-section level | PageHeader, SidebarNav |
+| `flow` | Multi-step / stateful | Wizard, Onboarding |
+| `overlay` | Layers above content | Modal, Drawer, Tooltip |
+
+### `domain`
+Use `"neutral"` for general-purpose components. Set to a product area (e.g. `"billing"`, `"auth"`) for domain-specific components.
+
+### `description`
+One sentence. Written for an AI audience — precise, not marketing copy.
+
+### `props`
+Full prop API. Each `PropDescriptor`:
+
+```ts
+interface PropDescriptor {
+  name:        string;
+  type:        PropType;       // "string" | "boolean" | "enum" | "ReactNode" | …
+  required:    boolean;
+  default?:    string;         // string representation of default value
+  description: string;
+  enumValues?: string[];       // for type: "enum"
+}
+```
+
+### `usageExamples`
+Code strings an AI can use directly. At minimum: one default usage + one edge case.
+
+```ts
+interface UsageExample {
+  title:        string;
+  code:         string;        // JSX / TSX
+  description?: string;
+}
+```
+
+### `compositionGraph`
+For molecules and above — the sub-components this component uses:
+
+```ts
+interface CompositionNode {
+  componentId:   string;
+  componentName: string;
+  role:          string;   // how it's used
+  required:      boolean;
+}
+```
+
+Atoms always have an empty `compositionGraph: []`.
+
+### `designIntent`
+**The most important field for AI-legibility.** Explain:
+- When to use each variant
+- What the component is optimised for
+- What it should *not* be used for
+- Any constraints or pairing rules
+
+Example:
+> "Use 'primary' for the single most important action in a view. Use 'danger' exclusively for destructive or irreversible operations — never for warnings."
+
+### `accessibility`
+Optional but recommended:
+
+```ts
+interface AccessibilityDescriptor {
+  role?:                 string;
+  ariaAttributes?:       string[];
+  keyboardInteractions?: string[];
+  notes?:                string;
+}
+```
+
+### `specVersion`
+`"MAJOR.MINOR"` — currently `"0.1"`. Consumers should check this field when parsing manifests.
+
+---
+
+## Validation
+
+```ts
+import { validateManifest, assertManifest } from 'lucent-ui';
+
+// Returns { valid: boolean, errors: ValidationError[] }
+const result = validateManifest(MyManifest);
+
+// Throws if invalid — use in tests
+assertManifest(MyManifest);
+```
+
+---
+
+## Example: Button manifest
+
+```ts
+import type { ComponentManifest } from 'lucent-ui';
+
+export const ButtonManifest: ComponentManifest = {
+  id: 'button',
+  name: 'Button',
+  tier: 'atom',
+  domain: 'neutral',
+  specVersion: '0.1',
+  description: 'A clickable control that triggers an action.',
+  designIntent:
+    'Use "primary" for the single most important action. Use "danger" exclusively ' +
+    'for destructive operations. Reserve "ghost" for low-emphasis actions in dense UIs.',
+  props: [
+    {
+      name: 'variant',
+      type: 'enum',
+      required: false,
+      default: 'primary',
+      description: 'Visual style conveying action hierarchy.',
+      enumValues: ['primary', 'secondary', 'ghost', 'danger'],
+    },
+    // …
+  ],
+  usageExamples: [
+    {
+      title: 'Primary action',
+      code: `<Button variant="primary" onClick={handleSave}>Save changes</Button>`,
+    },
+  ],
+  compositionGraph: [],
+};
+```
+
+---
+
+## Adopting this spec in your own library
+
+1. Install the types: `pnpm add -D lucent-ui` (types only — tree-shake the rest)
+2. Add a `COMPONENT_MANIFEST` export alongside each component
+3. Use `validateManifest()` in your test suite to enforce spec compliance
+4. Optionally: run your own MCP server pointing at your manifests
+
+See [lucentui.ai/spec](https://lucentui.ai/spec) for the full versioned specification.
+
+---
+
+## Versioning
+
+| Version | Status | Notes |
+|---|---|---|
+| 0.1 | Current | Initial spec — may change before 1.0 |
+| 1.0 | Planned | Stable, JSON Schema published |
+
+Breaking changes will increment the major version. Additive changes increment minor.

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,4 +6,24 @@ export type { LucentProviderProps } from './provider/index.js';
 export { lightTokens, darkTokens, makeLibraryCSS } from './tokens/index.js';
 export type { LucentTokens, Theme } from './tokens/index.js';
 
+export {
+  validateManifest,
+  assertManifest,
+  isValidPropDescriptor,
+  ButtonManifest,
+  MANIFEST_SPEC_VERSION,
+} from './manifest/index.js';
+export type {
+  ComponentManifest,
+  ComponentTier,
+  ComponentDomain,
+  PropDescriptor,
+  PropType,
+  UsageExample,
+  CompositionNode,
+  AccessibilityDescriptor,
+  ValidationResult,
+  ValidationError,
+} from './manifest/index.js';
+
 export const LUCENT_UI_VERSION = '0.1.0';

--- a/src/manifest/examples/button.manifest.ts
+++ b/src/manifest/examples/button.manifest.ts
@@ -1,0 +1,120 @@
+import type { ComponentManifest } from '../types.js';
+
+export const ButtonManifest: ComponentManifest = {
+  id: 'button',
+  name: 'Button',
+  tier: 'atom',
+  domain: 'neutral',
+  specVersion: '0.1',
+  description:
+    'A clickable control that triggers an action. The primary interactive primitive in Lucent UI.',
+  designIntent:
+    'Buttons communicate available actions. Variant conveys hierarchy: use "primary" for the ' +
+    'single most important action in a view, "secondary" for supporting actions, "ghost" for ' +
+    'low-emphasis actions in dense UIs, and "danger" exclusively for destructive or irreversible ' +
+    'operations. Size should match surrounding content density — prefer "md" as the default and ' +
+    'reserve "sm" for toolbars or tables.',
+  props: [
+    {
+      name: 'variant',
+      type: 'enum',
+      required: false,
+      default: 'primary',
+      description: 'Visual style conveying action hierarchy.',
+      enumValues: ['primary', 'secondary', 'ghost', 'danger'],
+    },
+    {
+      name: 'size',
+      type: 'enum',
+      required: false,
+      default: 'md',
+      description: 'Controls height and padding.',
+      enumValues: ['sm', 'md', 'lg'],
+    },
+    {
+      name: 'children',
+      type: 'ReactNode',
+      required: true,
+      description: 'Button label or content.',
+    },
+    {
+      name: 'disabled',
+      type: 'boolean',
+      required: false,
+      default: 'false',
+      description: 'Prevents interaction and applies disabled styling.',
+    },
+    {
+      name: 'loading',
+      type: 'boolean',
+      required: false,
+      default: 'false',
+      description: 'Shows a spinner and prevents interaction while an async action is in progress.',
+    },
+    {
+      name: 'fullWidth',
+      type: 'boolean',
+      required: false,
+      default: 'false',
+      description: 'Stretches the button to fill its container width.',
+    },
+    {
+      name: 'leftIcon',
+      type: 'ReactNode',
+      required: false,
+      description: 'Icon element rendered before the label.',
+    },
+    {
+      name: 'rightIcon',
+      type: 'ReactNode',
+      required: false,
+      description: 'Icon element rendered after the label.',
+    },
+    {
+      name: 'onClick',
+      type: 'function',
+      required: false,
+      description: 'Called when the button is clicked and not disabled or loading.',
+    },
+    {
+      name: 'type',
+      type: 'enum',
+      required: false,
+      default: 'button',
+      description: 'Native button type attribute.',
+      enumValues: ['button', 'submit', 'reset'],
+    },
+  ],
+  usageExamples: [
+    {
+      title: 'Primary action',
+      code: `<Button variant="primary" onClick={handleSave}>Save changes</Button>`,
+    },
+    {
+      title: 'Destructive action',
+      code: `<Button variant="danger" onClick={handleDelete}>Delete account</Button>`,
+    },
+    {
+      title: 'Loading state',
+      code: `<Button variant="primary" loading={isSaving}>Save changes</Button>`,
+    },
+    {
+      title: 'With icon',
+      code: `<Button variant="secondary" leftIcon={<PlusIcon />}>Add member</Button>`,
+    },
+    {
+      title: 'Ghost in toolbar',
+      code: `<Button variant="ghost" size="sm">Edit</Button>`,
+    },
+    {
+      title: 'Full-width submit',
+      code: `<Button variant="primary" type="submit" fullWidth>Sign in</Button>`,
+    },
+  ],
+  compositionGraph: [],
+  accessibility: {
+    role: 'button',
+    ariaAttributes: ['aria-disabled', 'aria-busy'],
+    keyboardInteractions: ['Enter — activates the button', 'Space — activates the button'],
+  },
+};

--- a/src/manifest/index.ts
+++ b/src/manifest/index.ts
@@ -1,0 +1,22 @@
+export type {
+  ComponentManifest,
+  ComponentTier,
+  ComponentDomain,
+  PropDescriptor,
+  PropType,
+  UsageExample,
+  CompositionNode,
+  AccessibilityDescriptor,
+} from './types.js';
+
+export {
+  validateManifest,
+  assertManifest,
+  isValidPropDescriptor,
+} from './validate.js';
+
+export type { ValidationResult, ValidationError } from './validate.js';
+
+export { ButtonManifest } from './examples/button.manifest.js';
+
+export const MANIFEST_SPEC_VERSION = '0.1';

--- a/src/manifest/types.ts
+++ b/src/manifest/types.ts
@@ -1,0 +1,135 @@
+/**
+ * The tier of a component in the design system hierarchy.
+ *
+ * - atom:     Indivisible UI primitive (Button, Input, Badge…)
+ * - molecule: Composition of atoms (FormField, Card, Alert…)
+ * - block:    Page-section-level composition (PageHeader, SidebarNav…)
+ * - flow:     Multi-step or stateful sequences (Wizard, Onboarding…)
+ * - overlay:  Layers above page content (Modal, Drawer, Tooltip…)
+ */
+export type ComponentTier = 'atom' | 'molecule' | 'block' | 'flow' | 'overlay';
+
+/**
+ * The domain of a component.
+ * "neutral" means the component is domain-agnostic and reusable
+ * across any product context.
+ */
+export type ComponentDomain = 'neutral' | string;
+
+// ─── Prop descriptor ────────────────────────────────────────────────────────
+
+export type PropType =
+  | 'string'
+  | 'number'
+  | 'boolean'
+  | 'ReactNode'
+  | 'function'
+  | 'enum'
+  | 'object'
+  | 'array'
+  | 'ref'
+  | string; // allow custom type strings like "ButtonVariant"
+
+export interface PropDescriptor {
+  /** Prop name as it appears in the component API */
+  name: string;
+  /** TypeScript type or custom type name */
+  type: PropType;
+  /** Whether the prop is required */
+  required: boolean;
+  /** Default value as a string representation */
+  default?: string;
+  /** Human-readable description for AI and documentation */
+  description: string;
+  /** For enum types — the allowed values */
+  enumValues?: readonly string[];
+}
+
+// ─── Usage example ──────────────────────────────────────────────────────────
+
+export interface UsageExample {
+  /** Short label for the example */
+  title: string;
+  /** JSX or TSX code string */
+  code: string;
+  /** Optional description of what this example demonstrates */
+  description?: string;
+}
+
+// ─── Composition graph ──────────────────────────────────────────────────────
+
+export interface CompositionNode {
+  /** Component id this node refers to */
+  componentId: string;
+  /** Human-readable name */
+  componentName: string;
+  /** How it is used in the composition */
+  role: string;
+  /** Whether this sub-component is always present or conditional */
+  required: boolean;
+}
+
+// ─── Accessibility ──────────────────────────────────────────────────────────
+
+export interface AccessibilityDescriptor {
+  /** ARIA role applied to the root element */
+  role?: string;
+  /** ARIA attributes used by this component */
+  ariaAttributes?: string[];
+  /** Keyboard interactions supported */
+  keyboardInteractions?: string[];
+  /** Plain-English notes for screen reader behaviour */
+  notes?: string;
+}
+
+// ─── Main manifest interface ─────────────────────────────────────────────────
+
+export interface ComponentManifest {
+  /**
+   * Unique identifier — kebab-case, e.g. "button", "form-field"
+   */
+  id: string;
+
+  /** Display name shown in docs and tooling */
+  name: string;
+
+  /** Position in the design system hierarchy */
+  tier: ComponentTier;
+
+  /**
+   * Product domain this component belongs to.
+   * Use "neutral" for general-purpose components.
+   */
+  domain: ComponentDomain;
+
+  /** One-sentence description for AI context */
+  description: string;
+
+  /** All accepted props */
+  props: readonly PropDescriptor[];
+
+  /** Code examples an AI can use to generate correct usage */
+  usageExamples: readonly UsageExample[];
+
+  /**
+   * For molecules, blocks, flows and overlays — the sub-components
+   * this component is composed from.
+   */
+  compositionGraph: readonly CompositionNode[];
+
+  /**
+   * Design intent: explain the "why" behind visual and interaction decisions.
+   * This is the key field for AI-legibility — it conveys context that
+   * prop types alone cannot.
+   */
+  designIntent: string;
+
+  /** Accessibility metadata */
+  accessibility?: AccessibilityDescriptor;
+
+  /**
+   * Spec version this manifest conforms to.
+   * Format: "MAJOR.MINOR" — e.g. "0.1"
+   */
+  specVersion: string;
+}

--- a/src/manifest/validate.ts
+++ b/src/manifest/validate.ts
@@ -1,0 +1,126 @@
+import type { ComponentManifest, PropDescriptor } from './types.js';
+
+export interface ValidationError {
+  field: string;
+  message: string;
+}
+
+export interface ValidationResult {
+  valid: boolean;
+  errors: ValidationError[];
+}
+
+function err(field: string, message: string): ValidationError {
+  return { field, message };
+}
+
+/**
+ * Validates a ComponentManifest object at runtime.
+ * Returns a result object — does not throw.
+ *
+ * @example
+ * const result = validateManifest(ButtonManifest);
+ * if (!result.valid) console.error(result.errors);
+ */
+export function validateManifest(manifest: unknown): ValidationResult {
+  const errors: ValidationError[] = [];
+
+  if (typeof manifest !== 'object' || manifest === null) {
+    return { valid: false, errors: [err('manifest', 'Must be a non-null object')] };
+  }
+
+  const m = manifest as Record<string, unknown>;
+
+  // Required string fields
+  const requiredStrings = ['id', 'name', 'description', 'designIntent', 'specVersion'] as const;
+  for (const field of requiredStrings) {
+    if (typeof m[field] !== 'string' || (m[field] as string).trim() === '') {
+      errors.push(err(field, `Must be a non-empty string`));
+    }
+  }
+
+  // id: kebab-case
+  if (typeof m['id'] === 'string' && !/^[a-z][a-z0-9-]*$/.test(m['id'])) {
+    errors.push(err('id', 'Must be kebab-case (e.g. "button", "form-field")'));
+  }
+
+  // tier
+  const validTiers = ['atom', 'molecule', 'block', 'flow', 'overlay'];
+  if (!validTiers.includes(m['tier'] as string)) {
+    errors.push(err('tier', `Must be one of: ${validTiers.join(', ')}`));
+  }
+
+  // domain
+  if (typeof m['domain'] !== 'string' || (m['domain'] as string).trim() === '') {
+    errors.push(err('domain', 'Must be a non-empty string'));
+  }
+
+  // props
+  if (!Array.isArray(m['props'])) {
+    errors.push(err('props', 'Must be an array'));
+  } else {
+    (m['props'] as unknown[]).forEach((prop, i) => {
+      const p = prop as Record<string, unknown>;
+      const prefix = `props[${i}]`;
+      if (typeof p['name'] !== 'string' || p['name'] === '')
+        errors.push(err(`${prefix}.name`, 'Must be a non-empty string'));
+      if (typeof p['type'] !== 'string' || p['type'] === '')
+        errors.push(err(`${prefix}.type`, 'Must be a non-empty string'));
+      if (typeof p['required'] !== 'boolean')
+        errors.push(err(`${prefix}.required`, 'Must be a boolean'));
+      if (typeof p['description'] !== 'string' || p['description'] === '')
+        errors.push(err(`${prefix}.description`, 'Must be a non-empty string'));
+    });
+  }
+
+  // usageExamples
+  if (!Array.isArray(m['usageExamples'])) {
+    errors.push(err('usageExamples', 'Must be an array'));
+  } else if ((m['usageExamples'] as unknown[]).length === 0) {
+    errors.push(err('usageExamples', 'Must have at least one example'));
+  } else {
+    (m['usageExamples'] as unknown[]).forEach((ex, i) => {
+      const e = ex as Record<string, unknown>;
+      const prefix = `usageExamples[${i}]`;
+      if (typeof e['title'] !== 'string' || e['title'] === '')
+        errors.push(err(`${prefix}.title`, 'Must be a non-empty string'));
+      if (typeof e['code'] !== 'string' || e['code'] === '')
+        errors.push(err(`${prefix}.code`, 'Must be a non-empty string'));
+    });
+  }
+
+  // compositionGraph
+  if (!Array.isArray(m['compositionGraph'])) {
+    errors.push(err('compositionGraph', 'Must be an array (empty array is fine for atoms)'));
+  }
+
+  // specVersion
+  if (typeof m['specVersion'] === 'string' && !/^\d+\.\d+$/.test(m['specVersion'])) {
+    errors.push(err('specVersion', 'Must be "MAJOR.MINOR" format, e.g. "0.1"'));
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+/**
+ * Asserts a manifest is valid. Throws a descriptive error if not.
+ * Use in tests or at component module load time.
+ */
+export function assertManifest(manifest: unknown): asserts manifest is ComponentManifest {
+  const result = validateManifest(manifest);
+  if (!result.valid) {
+    const messages = result.errors.map(e => `  ${e.field}: ${e.message}`).join('\n');
+    throw new Error(`Invalid ComponentManifest:\n${messages}`);
+  }
+}
+
+export function isValidPropDescriptor(prop: unknown): prop is PropDescriptor {
+  if (typeof prop !== 'object' || prop === null) return false;
+  const p = prop as Record<string, unknown>;
+  return (
+    typeof p['name'] === 'string' &&
+    typeof p['type'] === 'string' &&
+    typeof p['required'] === 'boolean' &&
+    typeof p['description'] === 'string'
+  );
+}


### PR DESCRIPTION
Closes #3

## Summary

- **`ComponentManifest` interface** — full TypeScript type covering id, name, tier, domain, description, props, usageExamples, compositionGraph, designIntent, accessibility, specVersion
- **Sub-types** — `PropDescriptor`, `UsageExample`, `CompositionNode`, `AccessibilityDescriptor`, `ComponentTier`, `ComponentDomain`
- **`validateManifest()`** — runtime validator, returns `{ valid, errors[] }`, does not throw
- **`assertManifest()`** — throws with descriptive message, for use in tests
- **Button reference manifest** — fully populated example at `src/manifest/examples/button.manifest.ts`
- **`docs/COMPONENT_MANIFEST_SPEC.md`** — standalone spec document covering all fields, validation, adoption guide, and versioning

## File layout

```
src/manifest/
  types.ts                    — all TypeScript interfaces
  validate.ts                 — validateManifest, assertManifest
  examples/
    button.manifest.ts        — reference implementation
  index.ts                    — public re-exports

docs/
  COMPONENT_MANIFEST_SPEC.md  — spec documentation
```

## Test plan

- [x] `pnpm build` clean
- [x] `ButtonManifest` satisfies `ComponentManifest` at compile time
- [x] `validateManifest(ButtonManifest)` returns `{ valid: true }`

🤖 Generated with [Claude Code](https://claude.com/claude-code)