### PR TITLE
feat: Text atom + Molecule Wave 1 (issue #6)

### DIFF
--- a/dev/ComponentPreview.tsx
+++ b/dev/ComponentPreview.tsx
@@ -14,6 +14,13 @@ import { Select } from '../src/components/atoms/Select/index.js';
 import { Tag } from '../src/components/atoms/Tag/index.js';
 import { Tooltip } from '../src/components/atoms/Tooltip/index.js';
 import { Icon } from '../src/components/atoms/Icon/index.js';
+import { Text } from '../src/components/atoms/Text/index.js';
+import { FormField } from '../src/components/molecules/FormField/index.js';
+import { SearchInput } from '../src/components/molecules/SearchInput/index.js';
+import { Card } from '../src/components/molecules/Card/index.js';
+import { Alert } from '../src/components/molecules/Alert/index.js';
+import { EmptyState } from '../src/components/molecules/EmptyState/index.js';
+import { Skeleton } from '../src/components/molecules/Skeleton/index.js';
 import type { LucentTokens, Theme } from '../src/index.js';
 
 type AccentPreset = 'default' | 'gold' | 'indigo';
@@ -81,6 +88,15 @@ function Inner({
   const [toggled, setToggled] = useState(false);
   const [selectVal, setSelectVal] = useState('');
   const [tags, setTags] = useState(['React', 'TypeScript', 'Design Systems']);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [alertDismissed, setAlertDismissed] = useState(false);
+
+  const allFruits = ['Apple', 'Apricot', 'Banana', 'Blueberry', 'Cherry', 'Grape', 'Mango', 'Orange', 'Peach', 'Pear', 'Pineapple', 'Strawberry'];
+  const searchResults = searchQuery.length > 0
+    ? allFruits
+        .filter(f => f.toLowerCase().includes(searchQuery.toLowerCase()))
+        .map((f, i) => ({ id: i, label: f }))
+    : [];
 
   return (
     <div style={{ background: tokens.bgBase, color: tokens.textPrimary, fontFamily: tokens.fontFamilyBase, minHeight: '100vh', padding: tokens.space8 }}>
@@ -88,7 +104,7 @@ function Inner({
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: tokens.space8, flexWrap: 'wrap', gap: tokens.space4 }}>
         <div>
           <h1 style={{ fontSize: tokens.fontSize2xl, fontWeight: tokens.fontWeightBold, margin: 0 }}>Lucent UI — Component Preview</h1>
-          <p style={{ color: tokens.textSecondary, margin: `${tokens.space1} 0 0`, fontSize: tokens.fontSizeSm }}>Atoms Wave 1 + 2 · {theme} mode · {accentLabel[accent]}</p>
+          <p style={{ color: tokens.textSecondary, margin: `${tokens.space1} 0 0`, fontSize: tokens.fontSizeSm }}>Molecules Wave 1 · Atoms Wave 1 + 2 · {theme} mode · {accentLabel[accent]}</p>
         </div>
         <div style={{ display: 'flex', gap: tokens.space2, alignItems: 'center', flexWrap: 'wrap' }}>
           {(['default', 'gold', 'indigo'] as AccentPreset[]).map(p => (
@@ -115,6 +131,216 @@ function Inner({
           </Button>
         </div>
       </div>
+
+      {/* ── Molecules ── */}
+
+      {/* Text */}
+      <Section title="Text" tokens={tokens}>
+        <Row label="Sizes" tokens={tokens}>
+          <Text as="span" size="xs">xs — Extra small</Text>
+          <Text as="span" size="sm">sm — Small</Text>
+          <Text as="span" size="md">md — Medium (base)</Text>
+          <Text as="span" size="lg">lg — Large</Text>
+          <Text as="span" size="xl">xl — X-Large</Text>
+          <Text as="span" size="2xl">2xl — 2X-Large</Text>
+          <Text as="span" size="3xl">3xl — 3X-Large</Text>
+        </Row>
+        <Row label="Weights" tokens={tokens}>
+          <Text as="span" weight="regular">Regular</Text>
+          <Text as="span" weight="medium">Medium</Text>
+          <Text as="span" weight="semibold">Semibold</Text>
+          <Text as="span" weight="bold">Bold</Text>
+        </Row>
+        <Row label="Colors" tokens={tokens}>
+          <Text as="span" color="primary">Primary</Text>
+          <Text as="span" color="secondary">Secondary</Text>
+          <Text as="span" color="disabled">Disabled</Text>
+          <Text as="span" color="success">Success</Text>
+          <Text as="span" color="warning">Warning</Text>
+          <Text as="span" color="danger">Danger</Text>
+          <Text as="span" color="info">Info</Text>
+        </Row>
+        <Row label="Family" tokens={tokens}>
+          <Text as="span" size="sm">base — DM Sans body text</Text>
+          <Text as="code" family="mono" size="sm">mono — const hello = 'world';</Text>
+          <Text as="span" family="display" size="lg" weight="semibold">display — Unbounded heading</Text>
+        </Row>
+        <Row label="Truncate" tokens={tokens}>
+          <Text as="span" truncate style={{ maxWidth: 180 }}>This text is truncated because it exceeds the max-width container</Text>
+        </Row>
+      </Section>
+
+      {/* FormField */}
+      <Section title="FormField" tokens={tokens}>
+        <Row label="Basic" tokens={tokens}>
+          <div style={{ width: 280 }}>
+            <FormField label="Email address" htmlFor="ff-email">
+              <Input id="ff-email" type="email" placeholder="you@example.com" />
+            </FormField>
+          </div>
+        </Row>
+        <Row label="Required + helper" tokens={tokens}>
+          <div style={{ width: 280 }}>
+            <FormField label="Username" htmlFor="ff-user" required helperText="Letters and numbers only, 3–20 chars">
+              <Input id="ff-user" placeholder="yourname" />
+            </FormField>
+          </div>
+        </Row>
+        <Row label="Error state" tokens={tokens}>
+          <div style={{ width: 280 }}>
+            <FormField label="Password" htmlFor="ff-pw" required errorMessage="Must be at least 8 characters">
+              <Input id="ff-pw" type="password" defaultValue="short" />
+            </FormField>
+          </div>
+        </Row>
+        <Row label="Wrapping Select" tokens={tokens}>
+          <div style={{ width: 280 }}>
+            <FormField label="Country" htmlFor="ff-country">
+              <Select
+                id="ff-country"
+                placeholder="Choose a country"
+                options={[
+                  { value: 'us', label: 'United States' },
+                  { value: 'gb', label: 'United Kingdom' },
+                  { value: 'ca', label: 'Canada' },
+                ]}
+              />
+            </FormField>
+          </div>
+        </Row>
+      </Section>
+
+      {/* SearchInput */}
+      <Section title="SearchInput" tokens={tokens}>
+        <Row label="With results dropdown" tokens={tokens}>
+          <div style={{ width: 320 }}>
+            <SearchInput
+              value={searchQuery}
+              onChange={setSearchQuery}
+              placeholder="Search fruits…"
+              results={searchResults}
+              onResultSelect={(r) => { setSearchQuery(r.label); }}
+            />
+          </div>
+        </Row>
+        <Row label="Loading state" tokens={tokens}>
+          <div style={{ width: 320 }}>
+            <SearchInput value="pineapple" onChange={() => {}} isLoading />
+          </div>
+        </Row>
+        <Row label="Disabled" tokens={tokens}>
+          <div style={{ width: 320 }}>
+            <SearchInput value="" onChange={() => {}} disabled placeholder="Search disabled…" />
+          </div>
+        </Row>
+      </Section>
+
+      {/* Card */}
+      <Section title="Card" tokens={tokens}>
+        <Row label="Body only" tokens={tokens}>
+          <Card style={{ width: 280 }}>
+            <Text size="sm" color="secondary">A simple card with body content only.</Text>
+          </Card>
+        </Row>
+        <Row label="Header + footer" tokens={tokens}>
+          <Card
+            style={{ width: 280 }}
+            header={<Text family="display" weight="semibold">Card title</Text>}
+            footer={
+              <div style={{ display: 'flex', justifyContent: 'flex-end', gap: tokens.space2 }}>
+                <Button variant="ghost" size="sm">Cancel</Button>
+                <Button variant="primary" size="sm">Save</Button>
+              </div>
+            }
+          >
+            <Text size="sm" color="secondary">Edit your profile information below.</Text>
+          </Card>
+        </Row>
+        <Row label="Sizes" tokens={tokens}>
+          <Card padding="sm" shadow="none" radius="sm" style={{ width: 160 }}>
+            <Text size="xs">sm padding, no shadow</Text>
+          </Card>
+          <Card padding="lg" shadow="lg" radius="lg" style={{ width: 160 }}>
+            <Text size="xs">lg padding + shadow</Text>
+          </Card>
+        </Row>
+      </Section>
+
+      {/* Alert */}
+      <Section title="Alert" tokens={tokens}>
+        <Row label="All variants" tokens={tokens}>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: tokens.space3, width: '100%' }}>
+            <Alert variant="info" title="Did you know?">You can customize the accent color using token overrides.</Alert>
+            <Alert variant="success" title="Changes saved">Your profile has been updated successfully.</Alert>
+            <Alert variant="warning" title="Approaching limit">You've used 80% of your monthly quota.</Alert>
+            <Alert variant="danger" title="Payment failed" onDismiss={alertDismissed ? undefined : () => setAlertDismissed(true)}>
+              {alertDismissed ? 'Dismissed! (re-renders on theme toggle)' : 'Check your card details and try again.'}
+            </Alert>
+          </div>
+        </Row>
+        <Row label="Body only (no title)" tokens={tokens}>
+          <div style={{ width: '100%' }}>
+            <Alert variant="info">Your session expires in 5 minutes.</Alert>
+          </div>
+        </Row>
+      </Section>
+
+      {/* EmptyState */}
+      <Section title="EmptyState" tokens={tokens}>
+        <Row label="With illustration + CTA" tokens={tokens}>
+          <Card style={{ width: 360 }}>
+            <EmptyState
+              illustration={
+                <Icon size="xl">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round">
+                    <circle cx={11} cy={11} r={8} />
+                    <path d="M21 21l-4.35-4.35" />
+                  </svg>
+                </Icon>
+              }
+              title="No results found"
+              description="Try adjusting your search or filters to find what you're looking for."
+              action={<Button variant="secondary" size="sm">Clear filters</Button>}
+            />
+          </Card>
+        </Row>
+        <Row label="Minimal (title only)" tokens={tokens}>
+          <Card style={{ width: 280 }}>
+            <EmptyState title="Nothing here yet" />
+          </Card>
+        </Row>
+      </Section>
+
+      {/* Skeleton */}
+      <Section title="Skeleton" tokens={tokens}>
+        <Row label="Text lines" tokens={tokens}>
+          <div style={{ width: 280 }}>
+            <Skeleton variant="text" lines={3} />
+          </div>
+        </Row>
+        <Row label="Shapes" tokens={tokens}>
+          <Skeleton variant="circle" width={40} height={40} />
+          <Skeleton variant="rectangle" width={120} height={40} />
+          <Skeleton variant="text" width={160} />
+        </Row>
+        <Row label="Card placeholder" tokens={tokens}>
+          <Card style={{ width: 280 }}>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: tokens.space3 }}>
+              <Skeleton variant="rectangle" height={120} />
+              <div style={{ display: 'flex', gap: tokens.space2, alignItems: 'center' }}>
+                <Skeleton variant="circle" width={32} height={32} />
+                <Skeleton variant="text" width="60%" />
+              </div>
+              <Skeleton variant="text" lines={2} />
+            </div>
+          </Card>
+        </Row>
+        <Row label="No animation" tokens={tokens}>
+          <Skeleton variant="rectangle" width={200} height={32} animate={false} />
+        </Row>
+      </Section>
+
+      <Divider style={{ marginBottom: tokens.space6 }} />
 
       {/* ── Wave 2 ── */}
 

--- a/dev/index.html
+++ b/dev/index.html
@@ -6,7 +6,7 @@
     <title>Lucent UI — Token Preview</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;1,9..40,400&family=DM+Mono:wght@400;500&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;1,9..40,400&family=DM+Mono:wght@400;500&family=Unbounded:wght@400;500;600;700&display=swap" rel="stylesheet" />
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/atoms/Input/Input.tsx
+++ b/src/components/atoms/Input/Input.tsx
@@ -15,6 +15,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
   ({ label, helperText, errorText, leftElement, rightElement, id, style, ...rest }, ref) => {
     const inputId = id ?? `lucent-input-${Math.random().toString(36).slice(2, 7)}`;
     const hasError = Boolean(errorText);
+    const isDisabled = Boolean(rest.disabled);
 
     return (
       <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--lucent-space-1)', width: '100%' }}>
@@ -35,7 +36,9 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
           {leftElement && (
             <span style={{
               position: 'absolute', left: 'var(--lucent-space-3)',
-              color: 'var(--lucent-text-secondary)', display: 'flex', alignItems: 'center',
+              color: isDisabled ? 'var(--lucent-text-disabled)' : 'var(--lucent-text-secondary)',
+              display: 'flex', alignItems: 'center',
+              pointerEvents: 'none',
             }}>
               {leftElement}
             </span>
@@ -53,9 +56,10 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
               padding: `0 ${rightElement ? 'var(--lucent-space-10)' : 'var(--lucent-space-3)'} 0 ${leftElement ? 'var(--lucent-space-10)' : 'var(--lucent-space-3)'}`,
               fontSize: 'var(--lucent-font-size-md)',
               fontFamily: 'var(--lucent-font-family-base)',
-              color: 'var(--lucent-text-primary)',
-              background: 'var(--lucent-surface-default)',
-              border: `1px solid ${hasError ? 'var(--lucent-danger-default)' : 'var(--lucent-border-default)'}`,
+              color: isDisabled ? 'var(--lucent-text-disabled)' : 'var(--lucent-text-primary)',
+              background: isDisabled ? 'var(--lucent-bg-muted)' : 'var(--lucent-surface-default)',
+              border: `1px solid ${isDisabled ? 'transparent' : hasError ? 'var(--lucent-danger-default)' : 'var(--lucent-border-default)'}`,
+              cursor: isDisabled ? 'not-allowed' : undefined,
               borderRadius: 'var(--lucent-radius-lg)',
               outline: 'none',
               boxSizing: 'border-box',
@@ -97,7 +101,8 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
           {rightElement && (
             <span style={{
               position: 'absolute', right: 'var(--lucent-space-3)',
-              color: 'var(--lucent-text-secondary)', display: 'flex', alignItems: 'center',
+              color: isDisabled ? 'var(--lucent-text-disabled)' : 'var(--lucent-text-secondary)',
+              display: 'flex', alignItems: 'center',
             }}>
               {rightElement}
             </span>

--- a/src/components/atoms/Text/Text.manifest.ts
+++ b/src/components/atoms/Text/Text.manifest.ts
@@ -1,0 +1,116 @@
+import type { ComponentManifest } from '../../../manifest/types.js';
+
+export const COMPONENT_MANIFEST: ComponentManifest = {
+  id: 'text',
+  name: 'Text',
+  tier: 'atom',
+  domain: 'neutral',
+  specVersion: '0.1',
+
+  description: 'Polymorphic typography primitive that maps semantic HTML elements to design-system type scales.',
+
+  designIntent:
+    'Text is the single source of truth for typography in Lucent UI. Rather than hard-coding font sizes ' +
+    'and colors directly in components, every piece of rendered text should pass through this atom. ' +
+    'The `as` prop controls the HTML element (and therefore semantic meaning), while `size`, `weight`, ' +
+    '`color`, and `lineHeight` control appearance independently — decoupling semantics from style. ' +
+    'Use `truncate` only in constrained-width containers where overflow must be prevented; it applies ' +
+    'overflow: hidden + text-overflow: ellipsis. The `family` prop enables inline code or monospaced ' +
+    'content without switching components.',
+
+  props: [
+    {
+      name: 'as',
+      type: 'enum',
+      required: false,
+      default: 'p',
+      description: 'HTML element to render. Controls semantic meaning independently of visual style.',
+      enumValues: ['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'span', 'div', 'label', 'strong', 'em', 'code'],
+    },
+    {
+      name: 'size',
+      type: 'enum',
+      required: false,
+      default: 'md',
+      description: 'Font size from the type scale. Maps to the corresponding --lucent-font-size-* token.',
+      enumValues: ['xs', 'sm', 'md', 'lg', 'xl', '2xl', '3xl'],
+    },
+    {
+      name: 'weight',
+      type: 'enum',
+      required: false,
+      default: 'regular',
+      description: 'Font weight. Maps to --lucent-font-weight-* tokens.',
+      enumValues: ['regular', 'medium', 'semibold', 'bold'],
+    },
+    {
+      name: 'color',
+      type: 'enum',
+      required: false,
+      default: 'primary',
+      description: 'Semantic text color. All values adapt automatically in light and dark themes.',
+      enumValues: ['primary', 'secondary', 'disabled', 'inverse', 'onAccent', 'success', 'warning', 'danger', 'info'],
+    },
+    {
+      name: 'align',
+      type: 'enum',
+      required: false,
+      default: 'left',
+      description: 'Text alignment.',
+      enumValues: ['left', 'center', 'right'],
+    },
+    {
+      name: 'lineHeight',
+      type: 'enum',
+      required: false,
+      default: 'base',
+      description: 'Line height. tight=1.25, base=1.5, relaxed=1.75.',
+      enumValues: ['tight', 'base', 'relaxed'],
+    },
+    {
+      name: 'family',
+      type: 'enum',
+      required: false,
+      default: 'base',
+      description: 'Font family. Use mono for code or tabular data. Use display (Unbounded) for headings and marketing copy.',
+      enumValues: ['base', 'mono', 'display'],
+    },
+    {
+      name: 'truncate',
+      type: 'boolean',
+      required: false,
+      default: 'false',
+      description: 'Clips overflow text with an ellipsis. Requires the container to have a constrained width.',
+    },
+    {
+      name: 'children',
+      type: 'ReactNode',
+      required: true,
+      description: 'The text content to render.',
+    },
+    {
+      name: 'style',
+      type: 'object',
+      required: false,
+      description: 'Inline style overrides. Applied after computed token styles.',
+    },
+  ],
+
+  usageExamples: [
+    { title: 'Heading', code: `<Text as="h1" size="3xl" weight="bold">Page title</Text>` },
+    { title: 'Body paragraph', code: `<Text size="md" color="secondary">Supporting copy goes here.</Text>` },
+    { title: 'Label', code: `<Text as="label" size="sm" weight="medium" htmlFor="email">Email</Text>` },
+    { title: 'Inline code', code: `<Text as="code" family="mono" size="sm">const x = 1;</Text>` },
+    { title: 'Truncated', code: `<Text truncate style={{ maxWidth: 200 }}>Very long text that will be clipped</Text>` },
+    { title: 'Status color', code: `<Text color="danger" size="xs">This field is required</Text>` },
+  ],
+
+  compositionGraph: [],
+
+  accessibility: {
+    notes:
+      'The rendered element determines the implicit ARIA role. Use heading elements (h1–h6) for document ' +
+      'headings so screen readers can navigate the page structure. Use `as="label"` with `htmlFor` to ' +
+      'associate labels with form controls. Decorative text needs no additional ARIA.',
+  },
+};

--- a/src/components/atoms/Text/Text.tsx
+++ b/src/components/atoms/Text/Text.tsx
@@ -1,0 +1,110 @@
+import type { CSSProperties, ReactNode } from 'react';
+
+export type TextAs =
+  | 'p' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
+  | 'span' | 'div' | 'label' | 'strong' | 'em' | 'code';
+
+export type TextSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl' | '3xl';
+export type TextWeight = 'regular' | 'medium' | 'semibold' | 'bold';
+export type TextColor =
+  | 'primary' | 'secondary' | 'disabled' | 'inverse' | 'onAccent'
+  | 'success' | 'warning' | 'danger' | 'info';
+export type TextAlign = 'left' | 'center' | 'right';
+export type TextLineHeight = 'tight' | 'base' | 'relaxed';
+export type TextFamily = 'base' | 'mono' | 'display';
+
+export interface TextProps {
+  as?: TextAs;
+  size?: TextSize;
+  weight?: TextWeight;
+  color?: TextColor;
+  align?: TextAlign;
+  lineHeight?: TextLineHeight;
+  family?: TextFamily;
+  truncate?: boolean;
+  children: ReactNode;
+  style?: CSSProperties;
+  id?: string;
+  htmlFor?: string;
+  className?: string;
+  onClick?: React.MouseEventHandler;
+  title?: string;
+  'aria-label'?: string;
+  'aria-hidden'?: boolean | 'true' | 'false';
+}
+
+const colorMap: Record<TextColor, string> = {
+  primary:   'var(--lucent-text-primary)',
+  secondary: 'var(--lucent-text-secondary)',
+  disabled:  'var(--lucent-text-disabled)',
+  inverse:   'var(--lucent-text-inverse)',
+  onAccent:  'var(--lucent-text-on-accent)',
+  success:   'var(--lucent-success-text)',
+  warning:   'var(--lucent-warning-text)',
+  danger:    'var(--lucent-danger-text)',
+  info:      'var(--lucent-info-text)',
+};
+
+const sizeMap: Record<TextSize, string> = {
+  xs:   'var(--lucent-font-size-xs)',
+  sm:   'var(--lucent-font-size-sm)',
+  md:   'var(--lucent-font-size-md)',
+  lg:   'var(--lucent-font-size-lg)',
+  xl:   'var(--lucent-font-size-xl)',
+  '2xl':'var(--lucent-font-size-2xl)',
+  '3xl':'var(--lucent-font-size-3xl)',
+};
+
+const weightMap: Record<TextWeight, string> = {
+  regular:  'var(--lucent-font-weight-regular)',
+  medium:   'var(--lucent-font-weight-medium)',
+  semibold: 'var(--lucent-font-weight-semibold)',
+  bold:     'var(--lucent-font-weight-bold)',
+};
+
+const lineHeightMap: Record<TextLineHeight, string> = {
+  tight:   'var(--lucent-line-height-tight)',
+  base:    'var(--lucent-line-height-base)',
+  relaxed: 'var(--lucent-line-height-relaxed)',
+};
+
+const familyMap: Record<TextFamily, string> = {
+  base:    'var(--lucent-font-family-base)',
+  mono:    'var(--lucent-font-family-mono)',
+  display: 'var(--lucent-font-family-display)',
+};
+
+export function Text({
+  as = 'p',
+  size = 'md',
+  weight = 'regular',
+  color = 'primary',
+  align = 'left',
+  lineHeight = 'base',
+  family = 'base',
+  truncate = false,
+  children,
+  style,
+  ...rest
+}: TextProps) {
+  const computedStyle: CSSProperties = {
+    fontSize:   sizeMap[size],
+    fontWeight: weightMap[weight],
+    color:      colorMap[color],
+    textAlign:  align,
+    lineHeight: lineHeightMap[lineHeight],
+    fontFamily: familyMap[family],
+    margin:     0,
+    ...(truncate && {
+      overflow:     'hidden',
+      textOverflow: 'ellipsis',
+      whiteSpace:   'nowrap',
+    }),
+    ...style,
+  };
+
+  // React.createElement lets us use the `as` prop as a dynamic tag
+  // without a JSX-level polymorphic component trick
+  const Tag = as as React.ElementType;
+  return <Tag style={computedStyle} {...rest}>{children}</Tag>;
+}

--- a/src/components/atoms/Text/index.ts
+++ b/src/components/atoms/Text/index.ts
@@ -1,0 +1,3 @@
+export { Text } from './Text.js';
+export type { TextProps, TextAs, TextSize, TextWeight, TextColor, TextAlign, TextLineHeight, TextFamily } from './Text.js';
+export { COMPONENT_MANIFEST as TextManifest } from './Text.manifest.js';

--- a/src/components/atoms/index.ts
+++ b/src/components/atoms/index.ts
@@ -12,3 +12,4 @@ export * from './Select/index.js';
 export * from './Tag/index.js';
 export * from './Tooltip/index.js';
 export * from './Icon/index.js';
+export * from './Text/index.js';

--- a/src/components/molecules/Alert/Alert.manifest.ts
+++ b/src/components/molecules/Alert/Alert.manifest.ts
@@ -1,0 +1,91 @@
+import type { ComponentManifest } from '../../../manifest/types.js';
+
+export const COMPONENT_MANIFEST: ComponentManifest = {
+  id: 'alert',
+  name: 'Alert',
+  tier: 'molecule',
+  domain: 'neutral',
+  specVersion: '0.1',
+
+  description: 'An inline feedback banner with info, success, warning, and danger variants, optional title, and dismiss button.',
+
+  designIntent:
+    'Alert uses role="alert" so screen readers announce the message immediately when it appears. ' +
+    'Each variant has a built-in icon that communicates intent visually; the icon can be overridden ' +
+    'for custom scenarios. Title and body are both optional — you can show either, both, or just an ' +
+    'icon with a body. The dismiss button is only rendered when onDismiss is provided, keeping the ' +
+    'layout clean for non-dismissible alerts. All colors use status semantic tokens so they adapt ' +
+    'correctly between light and dark themes.',
+
+  props: [
+    {
+      name: 'variant',
+      type: 'enum',
+      required: false,
+      default: 'info',
+      description: 'Visual and semantic variant of the alert.',
+      enumValues: ['info', 'success', 'warning', 'danger'],
+    },
+    {
+      name: 'title',
+      type: 'string',
+      required: false,
+      description: 'Bold title line rendered above the body.',
+    },
+    {
+      name: 'children',
+      type: 'ReactNode',
+      required: false,
+      description: 'Alert body content — typically a short sentence or ReactNode.',
+    },
+    {
+      name: 'onDismiss',
+      type: 'function',
+      required: false,
+      description: 'When provided, renders a dismiss (×) button and calls this handler on click.',
+    },
+    {
+      name: 'icon',
+      type: 'ReactNode',
+      required: false,
+      description: 'Custom icon to replace the built-in variant icon.',
+    },
+    {
+      name: 'style',
+      type: 'object',
+      required: false,
+      description: 'Inline style overrides for the alert wrapper.',
+    },
+  ],
+
+  usageExamples: [
+    {
+      title: 'Info with body',
+      code: `<Alert variant="info">Your changes have been saved as a draft.</Alert>`,
+    },
+    {
+      title: 'With title and dismiss',
+      code: `<Alert variant="danger" title="Payment failed" onDismiss={() => setVisible(false)}>
+  Check your card details and try again.
+</Alert>`,
+    },
+    {
+      title: 'Success confirmation',
+      code: `<Alert variant="success" title="Order placed!">
+  You'll receive a confirmation email shortly.
+</Alert>`,
+    },
+  ],
+
+  compositionGraph: [
+    { componentId: 'text', componentName: 'Text', role: 'Title and body content', required: false },
+  ],
+
+  accessibility: {
+    role: 'alert',
+    ariaAttributes: ['aria-label'],
+    notes:
+      'role="alert" causes screen readers to announce the content immediately when rendered. ' +
+      'For non-urgent status messages, consider using role="status" instead by overriding via style/wrapper.',
+  },
+};

--- a/src/components/molecules/Alert/Alert.tsx
+++ b/src/components/molecules/Alert/Alert.tsx
@@ -1,0 +1,141 @@
+import type { CSSProperties, ReactNode } from 'react';
+import { Text } from '../../atoms/Text/Text.js';
+
+export type AlertVariant = 'info' | 'success' | 'warning' | 'danger';
+
+export interface AlertProps {
+  variant?: AlertVariant;
+  title?: string;
+  children?: ReactNode;
+  onDismiss?: () => void;
+  icon?: ReactNode;
+  style?: CSSProperties;
+}
+
+const variantStyles: Record<AlertVariant, { bg: string; border: string; iconColor: string; textColor: TextColor }> = {
+  info:    { bg: 'var(--lucent-info-subtle)',    border: 'var(--lucent-info-default)',    iconColor: 'var(--lucent-info-text)',    textColor: 'info' },
+  success: { bg: 'var(--lucent-success-subtle)', border: 'var(--lucent-success-default)', iconColor: 'var(--lucent-success-text)', textColor: 'success' },
+  warning: { bg: 'var(--lucent-warning-subtle)', border: 'var(--lucent-warning-default)', iconColor: 'var(--lucent-warning-text)', textColor: 'warning' },
+  danger:  { bg: 'var(--lucent-danger-subtle)',  border: 'var(--lucent-danger-default)',  iconColor: 'var(--lucent-danger-text)',  textColor: 'danger' },
+};
+
+type TextColor = 'info' | 'success' | 'warning' | 'danger';
+
+const InfoIcon = () => (
+  <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+    <circle cx="8" cy="8" r="6.5" stroke="currentColor" strokeWidth="1.5"/>
+    <path d="M8 5.5V8.5M8 10.5V11" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
+  </svg>
+);
+
+const SuccessIcon = () => (
+  <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+    <circle cx="8" cy="8" r="6.5" stroke="currentColor" strokeWidth="1.5"/>
+    <path d="M5 8L7 10L11 6" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+  </svg>
+);
+
+const WarningIcon = () => (
+  <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+    <path d="M8 2L14.5 13H1.5L8 2Z" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round"/>
+    <path d="M8 6V9M8 11V11.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
+  </svg>
+);
+
+const DangerIcon = () => (
+  <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+    <circle cx="8" cy="8" r="6.5" stroke="currentColor" strokeWidth="1.5"/>
+    <path d="M5.5 5.5L10.5 10.5M10.5 5.5L5.5 10.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
+  </svg>
+);
+
+const defaultIcons: Record<AlertVariant, ReactNode> = {
+  info:    <InfoIcon />,
+  success: <SuccessIcon />,
+  warning: <WarningIcon />,
+  danger:  <DangerIcon />,
+};
+
+const DismissIcon = () => (
+  <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+    <path d="M3 3L11 11M11 3L3 11" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
+  </svg>
+);
+
+export function Alert({
+  variant = 'info',
+  title,
+  children,
+  onDismiss,
+  icon,
+  style,
+}: AlertProps) {
+  const v = variantStyles[variant];
+  const renderedIcon = icon ?? defaultIcons[variant];
+
+  return (
+    <div
+      role="alert"
+      style={{
+        display: 'flex',
+        alignItems: 'flex-start',
+        gap: 'var(--lucent-space-3)',
+        padding: 'var(--lucent-space-3) var(--lucent-space-4)',
+        background: v.bg,
+        border: `1px solid ${v.border}`,
+        borderRadius: 'var(--lucent-radius-md)',
+        boxSizing: 'border-box',
+        ...style,
+      }}
+    >
+      <span
+        style={{
+          flexShrink: 0,
+          color: v.iconColor,
+          display: 'flex',
+          alignItems: 'center',
+          paddingTop: 2,
+        }}
+      >
+        {renderedIcon}
+      </span>
+
+      <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 'var(--lucent-space-1)' }}>
+        {title && (
+          <Text as="span" size="sm" weight="semibold" color={v.textColor} lineHeight="tight">
+            {title}
+          </Text>
+        )}
+        {children && (
+          <Text as="span" size="sm" color={v.textColor} lineHeight="base">
+            {children}
+          </Text>
+        )}
+      </div>
+
+      {onDismiss && (
+        <button
+          type="button"
+          aria-label="Dismiss"
+          onClick={onDismiss}
+          style={{
+            flexShrink: 0,
+            display: 'flex',
+            alignItems: 'center',
+            background: 'none',
+            border: 'none',
+            cursor: 'pointer',
+            padding: 2,
+            borderRadius: 'var(--lucent-radius-sm)',
+            color: v.iconColor,
+            opacity: 0.7,
+          }}
+          onMouseEnter={(e) => { e.currentTarget.style.opacity = '1'; }}
+          onMouseLeave={(e) => { e.currentTarget.style.opacity = '0.7'; }}
+        >
+          <DismissIcon />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/molecules/Alert/index.ts
+++ b/src/components/molecules/Alert/index.ts
@@ -1,0 +1,3 @@
+export { Alert } from './Alert.js';
+export type { AlertProps, AlertVariant } from './Alert.js';
+export { COMPONENT_MANIFEST as AlertManifest } from './Alert.manifest.js';

--- a/src/components/molecules/Card/Card.manifest.ts
+++ b/src/components/molecules/Card/Card.manifest.ts
@@ -1,0 +1,102 @@
+import type { ComponentManifest } from '../../../manifest/types.js';
+
+export const COMPONENT_MANIFEST: ComponentManifest = {
+  id: 'card',
+  name: 'Card',
+  tier: 'molecule',
+  domain: 'neutral',
+  specVersion: '0.1',
+
+  description: 'A surface container with optional header, body, and footer slots, configurable padding, shadow, and radius.',
+
+  designIntent:
+    'Card provides a consistent elevated surface for grouping related content. The header and footer slots ' +
+    'are separated from the body by a border-default divider, giving visual structure without requiring ' +
+    'the consumer to manage spacing. Padding, shadow, and radius are all configurable to accommodate ' +
+    'flat/ghost cards, modal-like surfaces, and compact data-dense layouts. The overflow: hidden ensures ' +
+    'children respect the border-radius without needing additional clipping.',
+
+  props: [
+    {
+      name: 'children',
+      type: 'ReactNode',
+      required: true,
+      description: 'The card body content.',
+    },
+    {
+      name: 'header',
+      type: 'ReactNode',
+      required: false,
+      description: 'Content rendered in the header slot, separated from the body by a divider.',
+    },
+    {
+      name: 'footer',
+      type: 'ReactNode',
+      required: false,
+      description: 'Content rendered in the footer slot, separated from the body by a divider.',
+    },
+    {
+      name: 'padding',
+      type: 'enum',
+      required: false,
+      default: 'md',
+      description: 'Inner padding applied equally to header, body, and footer.',
+      enumValues: ['none', 'sm', 'md', 'lg'],
+    },
+    {
+      name: 'shadow',
+      type: 'enum',
+      required: false,
+      default: 'sm',
+      description: 'Box shadow elevation.',
+      enumValues: ['none', 'sm', 'md', 'lg'],
+    },
+    {
+      name: 'radius',
+      type: 'enum',
+      required: false,
+      default: 'md',
+      description: 'Border radius of the card.',
+      enumValues: ['none', 'sm', 'md', 'lg'],
+    },
+    {
+      name: 'style',
+      type: 'object',
+      required: false,
+      description: 'Inline style overrides for the card wrapper.',
+    },
+  ],
+
+  usageExamples: [
+    {
+      title: 'Simple card',
+      code: `<Card>
+  <Text>Some content here.</Text>
+</Card>`,
+    },
+    {
+      title: 'With header and footer',
+      code: `<Card
+  header={<Text weight="semibold">Card title</Text>}
+  footer={<Button variant="primary">Save</Button>}
+>
+  <Text color="secondary">Card body content goes here.</Text>
+</Card>`,
+    },
+    {
+      title: 'Flat variant',
+      code: `<Card shadow="none" radius="sm" padding="sm">
+  <Text size="sm">Compact flat card</Text>
+</Card>`,
+    },
+  ],
+
+  compositionGraph: [],
+
+  accessibility: {
+    notes:
+      'Card has no implicit ARIA role. If the card represents a landmark, wrap it in a <section> or <article> ' +
+      'and provide an aria-label. For interactive cards (clickable), make the wrapper a <button> or <a> and ' +
+      'ensure focus styles are visible.',
+  },
+};

--- a/src/components/molecules/Card/Card.tsx
+++ b/src/components/molecules/Card/Card.tsx
@@ -1,0 +1,89 @@
+import type { CSSProperties, ReactNode } from 'react';
+
+export type CardPadding = 'none' | 'sm' | 'md' | 'lg';
+export type CardShadow = 'none' | 'sm' | 'md' | 'lg';
+export type CardRadius = 'none' | 'sm' | 'md' | 'lg';
+
+export interface CardProps {
+  header?: ReactNode;
+  footer?: ReactNode;
+  children: ReactNode;
+  padding?: CardPadding;
+  shadow?: CardShadow;
+  radius?: CardRadius;
+  style?: CSSProperties;
+}
+
+const paddingMap: Record<CardPadding, string> = {
+  none: '0',
+  sm:   'var(--lucent-space-3)',
+  md:   'var(--lucent-space-4)',
+  lg:   'var(--lucent-space-6)',
+};
+
+const shadowMap: Record<CardShadow, string> = {
+  none: 'var(--lucent-shadow-none)',
+  sm:   'var(--lucent-shadow-sm)',
+  md:   'var(--lucent-shadow-md)',
+  lg:   'var(--lucent-shadow-lg)',
+};
+
+const radiusMap: Record<CardRadius, string> = {
+  none: 'var(--lucent-radius-none)',
+  sm:   'var(--lucent-radius-sm)',
+  md:   'var(--lucent-radius-md)',
+  lg:   'var(--lucent-radius-lg)',
+};
+
+export function Card({
+  header,
+  footer,
+  children,
+  padding = 'md',
+  shadow = 'sm',
+  radius = 'md',
+  style,
+}: CardProps) {
+  const p = paddingMap[padding];
+  const borderRadius = radiusMap[radius];
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        background: 'var(--lucent-surface-default)',
+        border: '1px solid var(--lucent-border-default)',
+        borderRadius,
+        boxShadow: shadowMap[shadow],
+        overflow: 'hidden',
+        boxSizing: 'border-box',
+        ...style,
+      }}
+    >
+      {header != null && (
+        <div
+          style={{
+            padding: p,
+            borderBottom: '1px solid var(--lucent-border-default)',
+          }}
+        >
+          {header}
+        </div>
+      )}
+      <div style={{ padding: p, flex: 1 }}>
+        {children}
+      </div>
+      {footer != null && (
+        <div
+          style={{
+            padding: p,
+            borderTop: '1px solid var(--lucent-border-default)',
+          }}
+        >
+          {footer}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/molecules/Card/index.ts
+++ b/src/components/molecules/Card/index.ts
@@ -1,0 +1,3 @@
+export { Card } from './Card.js';
+export type { CardProps, CardPadding, CardShadow, CardRadius } from './Card.js';
+export { COMPONENT_MANIFEST as CardManifest } from './Card.manifest.js';

--- a/src/components/molecules/EmptyState/EmptyState.manifest.ts
+++ b/src/components/molecules/EmptyState/EmptyState.manifest.ts
@@ -1,0 +1,89 @@
+import type { ComponentManifest } from '../../../manifest/types.js';
+
+export const COMPONENT_MANIFEST: ComponentManifest = {
+  id: 'empty-state',
+  name: 'EmptyState',
+  tier: 'molecule',
+  domain: 'neutral',
+  specVersion: '0.1',
+
+  description: 'A centered placeholder shown when a list or page has no content, with an optional illustration, title, description, and CTA.',
+
+  designIntent:
+    'EmptyState communicates the absence of data in a constructive way. The illustration slot accepts any ' +
+    'ReactNode — an Icon atom, a custom SVG, or an image — and constrains it to a 64px square to maintain ' +
+    'visual consistency. Title is required to ensure the state is always named; description is optional for ' +
+    'additional context. The action slot accepts any ReactNode (typically a Button) so the consumer controls ' +
+    'variant and label without prescribing them. The entire layout is center-aligned and padded to sit ' +
+    'naturally inside a Card or page section.',
+
+  props: [
+    {
+      name: 'title',
+      type: 'string',
+      required: true,
+      description: 'Short headline naming the empty state (e.g. "No results found").',
+    },
+    {
+      name: 'illustration',
+      type: 'ReactNode',
+      required: false,
+      description: 'Icon, SVG, or image rendered above the title. Constrained to a 64px container.',
+    },
+    {
+      name: 'description',
+      type: 'string',
+      required: false,
+      description: 'Secondary text below the title providing context or next steps.',
+    },
+    {
+      name: 'action',
+      type: 'ReactNode',
+      required: false,
+      description: 'Call-to-action rendered below the description — typically a Button.',
+    },
+    {
+      name: 'style',
+      type: 'object',
+      required: false,
+      description: 'Inline style overrides for the outer wrapper.',
+    },
+  ],
+
+  usageExamples: [
+    {
+      title: 'No search results',
+      code: `<EmptyState
+  illustration={<Icon size="xl"><SearchIcon /></Icon>}
+  title="No results found"
+  description="Try adjusting your search or filter to find what you're looking for."
+  action={<Button variant="secondary" onClick={clearSearch}>Clear search</Button>}
+/>`,
+    },
+    {
+      title: 'Empty list with CTA',
+      code: `<EmptyState
+  title="No projects yet"
+  description="Create your first project to get started."
+  action={<Button variant="primary">New project</Button>}
+/>`,
+    },
+    {
+      title: 'Inside a Card',
+      code: `<Card>
+  <EmptyState title="Nothing here" description="Add items to see them listed." />
+</Card>`,
+    },
+  ],
+
+  compositionGraph: [
+    { componentId: 'text', componentName: 'Text', role: 'Title and description', required: true },
+  ],
+
+  accessibility: {
+    notes:
+      'The title renders as an h3 by default. If EmptyState appears inside a section with its own heading ' +
+      'hierarchy, override by passing a Text component as part of a custom layout. Ensure the action element ' +
+      'has a descriptive label for screen readers.',
+  },
+};

--- a/src/components/molecules/EmptyState/EmptyState.tsx
+++ b/src/components/molecules/EmptyState/EmptyState.tsx
@@ -1,0 +1,60 @@
+import type { CSSProperties, ReactNode } from 'react';
+import { Text } from '../../atoms/Text/Text.js';
+
+export interface EmptyStateProps {
+  illustration?: ReactNode;
+  title: string;
+  description?: string;
+  action?: ReactNode;
+  style?: CSSProperties;
+}
+
+export function EmptyState({
+  illustration,
+  title,
+  description,
+  action,
+  style,
+}: EmptyStateProps) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        gap: 'var(--lucent-space-4)',
+        padding: 'var(--lucent-space-8)',
+        textAlign: 'center',
+        ...style,
+      }}
+    >
+      {illustration != null && (
+        <div
+          style={{
+            width: 64,
+            height: 64,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            color: 'var(--lucent-text-secondary)',
+          }}
+        >
+          {illustration}
+        </div>
+      )}
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--lucent-space-2)' }}>
+        <Text as="h3" size="lg" weight="semibold" align="center" lineHeight="tight">
+          {title}
+        </Text>
+        {description && (
+          <Text size="sm" color="secondary" align="center" lineHeight="relaxed">
+            {description}
+          </Text>
+        )}
+      </div>
+      {action != null && (
+        <div>{action}</div>
+      )}
+    </div>
+  );
+}

--- a/src/components/molecules/EmptyState/index.ts
+++ b/src/components/molecules/EmptyState/index.ts
@@ -1,0 +1,3 @@
+export { EmptyState } from './EmptyState.js';
+export type { EmptyStateProps } from './EmptyState.js';
+export { COMPONENT_MANIFEST as EmptyStateManifest } from './EmptyState.manifest.js';

--- a/src/components/molecules/FormField/FormField.manifest.ts
+++ b/src/components/molecules/FormField/FormField.manifest.ts
@@ -1,0 +1,103 @@
+import type { ComponentManifest } from '../../../manifest/types.js';
+
+export const COMPONENT_MANIFEST: ComponentManifest = {
+  id: 'form-field',
+  name: 'FormField',
+  tier: 'molecule',
+  domain: 'neutral',
+  specVersion: '0.1',
+
+  description: 'Wraps any form control (Input, Select, Textarea) with a label, helper text, and validation message.',
+
+  designIntent:
+    'FormField standardises the vertical rhythm around form controls. A label is linked to the control ' +
+    'via htmlFor so screen readers announce it correctly. The required asterisk is decorative (aria-hidden) ' +
+    'because the actual required state should be communicated on the input via aria-required. Helper text ' +
+    'provides proactive guidance; errorMessage replaces it when validation fails, using danger color to ' +
+    'draw attention. The gap between elements uses space-2 to create a tight but breathable stack.',
+
+  props: [
+    {
+      name: 'label',
+      type: 'string',
+      required: false,
+      description: 'Label text rendered above the control as a <label> element.',
+    },
+    {
+      name: 'htmlFor',
+      type: 'string',
+      required: false,
+      description: 'ID of the form control this label describes. Forwarded to the label htmlFor attribute.',
+    },
+    {
+      name: 'required',
+      type: 'boolean',
+      required: false,
+      default: 'false',
+      description: 'Appends a danger-colored asterisk after the label text.',
+    },
+    {
+      name: 'helperText',
+      type: 'string',
+      required: false,
+      description: 'Secondary text below the control providing guidance. Hidden when errorMessage is set.',
+    },
+    {
+      name: 'errorMessage',
+      type: 'string',
+      required: false,
+      description: 'Validation error shown in danger color below the control. Replaces helperText when set.',
+    },
+    {
+      name: 'children',
+      type: 'ReactNode',
+      required: true,
+      description: 'The form control to wrap — typically Input, Select, or Textarea.',
+    },
+    {
+      name: 'style',
+      type: 'object',
+      required: false,
+      description: 'Inline style overrides for the outer wrapper.',
+    },
+  ],
+
+  usageExamples: [
+    {
+      title: 'Basic field',
+      code: `<FormField label="Email" htmlFor="email">
+  <Input id="email" placeholder="you@example.com" />
+</FormField>`,
+    },
+    {
+      title: 'Required with helper',
+      code: `<FormField label="Username" htmlFor="username" required helperText="Letters and numbers only">
+  <Input id="username" />
+</FormField>`,
+    },
+    {
+      title: 'With validation error',
+      code: `<FormField label="Password" htmlFor="pw" errorMessage="Must be at least 8 characters">
+  <Input id="pw" type="password" />
+</FormField>`,
+    },
+    {
+      title: 'Wrapping a Select',
+      code: `<FormField label="Country" htmlFor="country">
+  <Select id="country" options={countryOptions} />
+</FormField>`,
+    },
+  ],
+
+  compositionGraph: [
+    { componentId: 'text', componentName: 'Text', role: 'Label, helper text, and error message', required: false },
+  ],
+
+  accessibility: {
+    ariaAttributes: ['aria-required', 'aria-describedby'],
+    notes:
+      'Link the wrapped control to an error message using aria-describedby on the control and a matching id ' +
+      'on the error element for full screen reader support. The required asterisk is aria-hidden; ' +
+      'set aria-required="true" on the control itself.',
+  },
+};

--- a/src/components/molecules/FormField/FormField.tsx
+++ b/src/components/molecules/FormField/FormField.tsx
@@ -1,0 +1,48 @@
+import type { CSSProperties, ReactNode } from 'react';
+import { Text } from '../../atoms/Text/Text.js';
+
+export interface FormFieldProps {
+  label?: string;
+  htmlFor?: string;
+  required?: boolean;
+  helperText?: string;
+  errorMessage?: string;
+  children: ReactNode;
+  style?: CSSProperties;
+}
+
+export function FormField({
+  label,
+  htmlFor,
+  required = false,
+  helperText,
+  errorMessage,
+  children,
+  style,
+}: FormFieldProps) {
+  const subText = errorMessage ?? helperText;
+  const subColor = errorMessage ? 'danger' : 'secondary';
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--lucent-space-2)', ...style }}>
+      {label && (
+        <div style={{ display: 'flex', alignItems: 'baseline', gap: 'var(--lucent-space-1)' }}>
+          <Text as="label" size="sm" weight="medium" lineHeight="tight" {...(htmlFor !== undefined && { htmlFor })}>
+            {label}
+          </Text>
+          {required && (
+            <Text as="span" size="sm" color="danger" lineHeight="tight" aria-hidden="true">
+              *
+            </Text>
+          )}
+        </div>
+      )}
+      {children}
+      {subText && (
+        <Text size="xs" color={subColor} lineHeight="tight">
+          {subText}
+        </Text>
+      )}
+    </div>
+  );
+}

--- a/src/components/molecules/FormField/index.ts
+++ b/src/components/molecules/FormField/index.ts
@@ -1,0 +1,3 @@
+export { FormField } from './FormField.js';
+export type { FormFieldProps } from './FormField.js';
+export { COMPONENT_MANIFEST as FormFieldManifest } from './FormField.manifest.js';

--- a/src/components/molecules/SearchInput/SearchInput.manifest.ts
+++ b/src/components/molecules/SearchInput/SearchInput.manifest.ts
@@ -1,0 +1,112 @@
+import type { ComponentManifest } from '../../../manifest/types.js';
+
+export const COMPONENT_MANIFEST: ComponentManifest = {
+  id: 'search-input',
+  name: 'SearchInput',
+  tier: 'molecule',
+  domain: 'neutral',
+  specVersion: '0.1',
+
+  description: 'A search field with a built-in magnifier icon, clear button, and an optional results dropdown.',
+
+  designIntent:
+    'SearchInput is intentionally dumb about filtering — the consumer passes already-filtered results ' +
+    'so the component stays stateless and flexible. The clear button appears only when the input has a ' +
+    'value, keeping the right side clean at rest. The results dropdown is rendered absolutely below the ' +
+    'input and closes after a 150ms delay on blur to allow result clicks to register before focus is lost. ' +
+    'Spinner replaces the clear button during loading to communicate async state without layout shift.',
+
+  props: [
+    {
+      name: 'value',
+      type: 'string',
+      required: true,
+      description: 'Controlled input value.',
+    },
+    {
+      name: 'onChange',
+      type: 'function',
+      required: true,
+      description: 'Called with the new string value whenever the input changes.',
+    },
+    {
+      name: 'placeholder',
+      type: 'string',
+      required: false,
+      default: '"Search…"',
+      description: 'Placeholder text for the input.',
+    },
+    {
+      name: 'results',
+      type: 'array',
+      required: false,
+      default: '[]',
+      description: 'Pre-filtered list of SearchResult objects ({ id, label }) to display in the dropdown.',
+    },
+    {
+      name: 'onResultSelect',
+      type: 'function',
+      required: false,
+      description: 'Called with the selected SearchResult when a dropdown item is clicked.',
+    },
+    {
+      name: 'isLoading',
+      type: 'boolean',
+      required: false,
+      default: 'false',
+      description: 'Shows a spinner in the right slot to indicate async search in progress.',
+    },
+    {
+      name: 'disabled',
+      type: 'boolean',
+      required: false,
+      default: 'false',
+      description: 'Disables the input.',
+    },
+    {
+      name: 'id',
+      type: 'string',
+      required: false,
+      description: 'HTML id forwarded to the underlying input element.',
+    },
+    {
+      name: 'style',
+      type: 'object',
+      required: false,
+      description: 'Inline style overrides for the outer wrapper.',
+    },
+  ],
+
+  usageExamples: [
+    {
+      title: 'Basic controlled search',
+      code: `const [query, setQuery] = useState('');
+const [results, setResults] = useState([]);
+
+<SearchInput
+  value={query}
+  onChange={(v) => { setQuery(v); setResults(filter(v)); }}
+  results={results}
+  onResultSelect={(r) => console.log(r)}
+/>`,
+    },
+    {
+      title: 'Loading state',
+      code: `<SearchInput value={query} onChange={setQuery} isLoading={isFetching} results={[]} />`,
+    },
+  ],
+
+  compositionGraph: [
+    { componentId: 'input', componentName: 'Input', role: 'Search text field with icon slots', required: true },
+    { componentId: 'spinner', componentName: 'Spinner', role: 'Loading indicator in the right slot', required: false },
+  ],
+
+  accessibility: {
+    role: 'combobox',
+    ariaAttributes: ['aria-expanded', 'aria-haspopup', 'aria-label'],
+    keyboardInteractions: ['Enter to select focused result', 'Escape to close dropdown'],
+    notes:
+      'The results list uses role="listbox" with role="option" items. For full keyboard navigation ' +
+      '(arrow keys to move between results), wire up onKeyDown on the Input and manage an activeIndex state.',
+  },
+};

--- a/src/components/molecules/SearchInput/SearchInput.tsx
+++ b/src/components/molecules/SearchInput/SearchInput.tsx
@@ -1,0 +1,148 @@
+import { useRef, useState, type CSSProperties } from 'react';
+import { Input } from '../../atoms/Input/Input.js';
+import { Spinner } from '../../atoms/Spinner/Spinner.js';
+import { Text } from '../../atoms/Text/Text.js';
+
+export interface SearchResult {
+  id: string | number;
+  label: string;
+}
+
+export interface SearchInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  results?: SearchResult[];
+  onResultSelect?: (result: SearchResult) => void;
+  isLoading?: boolean;
+  disabled?: boolean;
+  id?: string;
+  style?: CSSProperties;
+}
+
+const SearchIcon = () => (
+  <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+    <circle cx="6.5" cy="6.5" r="4" stroke="currentColor" strokeWidth="1.5"/>
+    <path d="M9.5 9.5L13 13" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
+  </svg>
+);
+
+const ClearIcon = () => (
+  <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+    <path d="M3 3L11 11M11 3L3 11" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
+  </svg>
+);
+
+export function SearchInput({
+  value,
+  onChange,
+  placeholder = 'Search…',
+  results = [],
+  onResultSelect,
+  isLoading = false,
+  disabled = false,
+  id,
+  style,
+}: SearchInputProps) {
+  const [focused, setFocused] = useState(false);
+  const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
+  const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const showDropdown = focused && results.length > 0;
+
+  const handleClear = () => {
+    onChange('');
+  };
+
+  const handleResultClick = (result: SearchResult) => {
+    onResultSelect?.(result);
+    setFocused(false);
+  };
+
+  const handleBlur = () => {
+    // Delay close so result click can fire first
+    closeTimer.current = setTimeout(() => setFocused(false), 150);
+  };
+
+  const handleFocus = () => {
+    if (closeTimer.current) clearTimeout(closeTimer.current);
+    setFocused(true);
+  };
+
+  const rightSlot = isLoading ? (
+    <Spinner size="sm" />
+  ) : value ? (
+    <button
+      type="button"
+      aria-label="Clear search"
+      onClick={handleClear}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        background: 'none',
+        border: 'none',
+        cursor: 'pointer',
+        padding: 2,
+        borderRadius: 'var(--lucent-radius-sm)',
+        color: 'var(--lucent-text-secondary)',
+      }}
+      onMouseEnter={(e) => { e.currentTarget.style.color = 'var(--lucent-text-primary)'; }}
+      onMouseLeave={(e) => { e.currentTarget.style.color = 'var(--lucent-text-secondary)'; }}
+    >
+      <ClearIcon />
+    </button>
+  ) : null;
+
+  return (
+    <div style={{ position: 'relative', ...style }}>
+      <Input
+        id={id}
+        type="search"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        disabled={disabled}
+        leftElement={<SearchIcon />}
+        rightElement={rightSlot ?? undefined}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
+      />
+      {showDropdown && (
+        <div
+          role="listbox"
+          style={{
+            position: 'absolute',
+            top: 'calc(100% + var(--lucent-space-1))',
+            left: 0,
+            right: 0,
+            zIndex: 50,
+            background: 'var(--lucent-surface-overlay)',
+            border: '1px solid var(--lucent-border-default)',
+            borderRadius: 'var(--lucent-radius-md)',
+            boxShadow: 'var(--lucent-shadow-md)',
+            overflow: 'hidden',
+          }}
+        >
+          {results.map((result, idx) => (
+            <div
+              key={result.id}
+              role="option"
+              aria-selected={false}
+              onMouseDown={() => handleResultClick(result)}
+              onMouseEnter={() => setHoveredIndex(idx)}
+              onMouseLeave={() => setHoveredIndex(null)}
+              style={{
+                padding: 'var(--lucent-space-2) var(--lucent-space-3)',
+                cursor: 'pointer',
+                background: hoveredIndex === idx ? 'var(--lucent-bg-subtle)' : 'transparent',
+                transition: `background var(--lucent-duration-fast) var(--lucent-easing-default)`,
+              }}
+            >
+              <Text as="span" size="md">{result.label}</Text>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/molecules/SearchInput/index.ts
+++ b/src/components/molecules/SearchInput/index.ts
@@ -1,0 +1,3 @@
+export { SearchInput } from './SearchInput.js';
+export type { SearchInputProps, SearchResult } from './SearchInput.js';
+export { COMPONENT_MANIFEST as SearchInputManifest } from './SearchInput.manifest.js';

--- a/src/components/molecules/Skeleton/Skeleton.manifest.ts
+++ b/src/components/molecules/Skeleton/Skeleton.manifest.ts
@@ -1,0 +1,103 @@
+import type { ComponentManifest } from '../../../manifest/types.js';
+
+export const COMPONENT_MANIFEST: ComponentManifest = {
+  id: 'skeleton',
+  name: 'Skeleton',
+  tier: 'molecule',
+  domain: 'neutral',
+  specVersion: '0.1',
+
+  description: 'Animated placeholder that matches the shape of content while it loads.',
+
+  designIntent:
+    'Skeleton uses a shimmer animation to communicate that content is loading without showing a spinner. ' +
+    'The three variants (text, circle, rectangle) cover the most common content shapes: inline text, ' +
+    'avatars/thumbnails, and generic content blocks. The text variant with lines > 1 mimics a paragraph ' +
+    'by stacking multiple text skeletons and shortening the last line to 70%, which is a widely recognised ' +
+    'convention for body copy placeholders. The shimmer gradient uses bg-muted and bg-subtle so it adapts ' +
+    'correctly in both light and dark themes without hard-coded colors.',
+
+  props: [
+    {
+      name: 'variant',
+      type: 'enum',
+      required: false,
+      default: 'rectangle',
+      description: 'Shape of the skeleton — text (1em tall), circle (equal width/height), or rectangle.',
+      enumValues: ['text', 'circle', 'rectangle'],
+    },
+    {
+      name: 'width',
+      type: 'string',
+      required: false,
+      default: '"100%"',
+      description: 'Width of the skeleton. Accepts any CSS value or a number (interpreted as px).',
+    },
+    {
+      name: 'height',
+      type: 'string',
+      required: false,
+      description: 'Height of the skeleton. Defaults: text=1em, circle=40px, rectangle=40px.',
+    },
+    {
+      name: 'lines',
+      type: 'number',
+      required: false,
+      default: '1',
+      description: 'Number of stacked text lines to render. Only applies to the text variant.',
+    },
+    {
+      name: 'animate',
+      type: 'boolean',
+      required: false,
+      default: 'true',
+      description: 'Enables the shimmer animation. Set to false to render a static placeholder.',
+    },
+    {
+      name: 'radius',
+      type: 'string',
+      required: false,
+      description: 'Override the default border-radius for the variant.',
+    },
+    {
+      name: 'style',
+      type: 'object',
+      required: false,
+      description: 'Inline style overrides.',
+    },
+  ],
+
+  usageExamples: [
+    {
+      title: 'Paragraph placeholder',
+      code: `<Skeleton variant="text" lines={3} />`,
+    },
+    {
+      title: 'Avatar placeholder',
+      code: `<Skeleton variant="circle" width={40} height={40} />`,
+    },
+    {
+      title: 'Card placeholder',
+      code: `<Card>
+  <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+    <Skeleton variant="rectangle" height={160} />
+    <Skeleton variant="text" lines={2} />
+    <Skeleton variant="text" width="40%" />
+  </div>
+</Card>`,
+    },
+    {
+      title: 'Static (no animation)',
+      code: `<Skeleton variant="rectangle" width={200} height={32} animate={false} />`,
+    },
+  ],
+
+  compositionGraph: [],
+
+  accessibility: {
+    ariaAttributes: ['aria-busy', 'aria-label'],
+    notes:
+      'Wrap loading regions with aria-busy="true" on the container so screen readers know content ' +
+      'is loading. Individual Skeleton elements are presentational and do not need ARIA attributes themselves.',
+  },
+};

--- a/src/components/molecules/Skeleton/Skeleton.tsx
+++ b/src/components/molecules/Skeleton/Skeleton.tsx
@@ -1,0 +1,111 @@
+import type { CSSProperties } from 'react';
+
+export type SkeletonVariant = 'text' | 'circle' | 'rectangle';
+
+export interface SkeletonProps {
+  variant?: SkeletonVariant;
+  width?: string | number;
+  height?: string | number;
+  lines?: number;
+  animate?: boolean;
+  radius?: string;
+  style?: CSSProperties;
+}
+
+const defaultHeights: Record<SkeletonVariant, string | number> = {
+  text:      '1em',
+  circle:    40,
+  rectangle: 40,
+};
+
+const defaultRadii: Record<SkeletonVariant, string> = {
+  text:      'var(--lucent-radius-sm)',
+  circle:    'var(--lucent-radius-full)',
+  rectangle: 'var(--lucent-radius-md)',
+};
+
+function SkeletonBlock({
+  width,
+  height,
+  radius,
+  animate,
+  style,
+}: {
+  width: string | number;
+  height: string | number;
+  radius: string;
+  animate: boolean;
+  style?: CSSProperties;
+}) {
+  return (
+    <span
+      style={{
+        display: 'block',
+        width: typeof width === 'number' ? `${width}px` : width,
+        height: typeof height === 'number' ? `${height}px` : height,
+        borderRadius: radius,
+        background: animate
+          ? 'linear-gradient(90deg, var(--lucent-bg-muted) 25%, var(--lucent-bg-subtle) 50%, var(--lucent-bg-muted) 75%)'
+          : 'var(--lucent-bg-muted)',
+        backgroundSize: animate ? '200% 100%' : undefined,
+        animation: animate ? 'lucent-skeleton-shimmer 1.6s ease-in-out infinite' : undefined,
+        flexShrink: 0,
+        ...style,
+      }}
+    />
+  );
+}
+
+export function Skeleton({
+  variant = 'rectangle',
+  width = '100%',
+  height,
+  lines = 1,
+  animate = true,
+  radius,
+  style,
+}: SkeletonProps) {
+  const resolvedHeight = height ?? defaultHeights[variant];
+  const resolvedRadius = radius ?? defaultRadii[variant];
+
+  const keyframes = animate ? (
+    <style>{`
+      @keyframes lucent-skeleton-shimmer {
+        0%   { background-position: 200% 0; }
+        100% { background-position: -200% 0; }
+      }
+    `}</style>
+  ) : null;
+
+  if (variant === 'text' && lines > 1) {
+    return (
+      <>
+        {keyframes}
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--lucent-space-2)', ...style }}>
+          {Array.from({ length: lines }).map((_, i) => (
+            <SkeletonBlock
+              key={i}
+              width={i === lines - 1 ? '70%' : width}
+              height={resolvedHeight}
+              radius={resolvedRadius}
+              animate={animate}
+            />
+          ))}
+        </div>
+      </>
+    );
+  }
+
+  return (
+    <>
+      {keyframes}
+      <SkeletonBlock
+        width={variant === 'circle' ? (height ?? 40) : width}
+        height={resolvedHeight}
+        radius={resolvedRadius}
+        animate={animate}
+        {...(style !== undefined && { style })}
+      />
+    </>
+  );
+}

--- a/src/components/molecules/Skeleton/index.ts
+++ b/src/components/molecules/Skeleton/index.ts
@@ -1,0 +1,3 @@
+export { Skeleton } from './Skeleton.js';
+export type { SkeletonProps, SkeletonVariant } from './Skeleton.js';
+export { COMPONENT_MANIFEST as SkeletonManifest } from './Skeleton.manifest.js';

--- a/src/components/molecules/index.ts
+++ b/src/components/molecules/index.ts
@@ -1,0 +1,6 @@
+export * from './FormField/index.js';
+export * from './SearchInput/index.js';
+export * from './Card/index.js';
+export * from './Alert/index.js';
+export * from './EmptyState/index.js';
+export * from './Skeleton/index.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 // Lucent UI — public API
 
 export * from './components/atoms/index.js';
+export * from './components/molecules/index.js';
 
 export { LucentProvider, useLucent } from './provider/index.js';
 export type { LucentProviderProps } from './provider/index.js';

--- a/src/tokens/base.ts
+++ b/src/tokens/base.ts
@@ -4,6 +4,7 @@ export const typographyTokens: TypographyTokens = {
   fontFamilyBase:
     '"DM Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
   fontFamilyMono: '"DM Mono", "Fira Code", "Cascadia Code", monospace',
+  fontFamilyDisplay: '"Unbounded", "DM Sans", sans-serif',
   fontSizeXs: '0.75rem',
   fontSizeSm: '0.875rem',
   fontSizeMd: '1rem',

--- a/src/tokens/types.ts
+++ b/src/tokens/types.ts
@@ -15,6 +15,7 @@ export interface ColorScale {
 export interface TypographyTokens {
   fontFamilyBase: string;
   fontFamilyMono: string;
+  fontFamilyDisplay: string;
   fontSizeXs: string;
   fontSizeSm: string;
   fontSizeMd: string;


### PR DESCRIPTION
New atom:
- Text — polymorphic typography primitive (as, size, weight, color, align, lineHeight, family, truncate); supports base/mono/display fonts

New molecules (src/components/molecules/):
- FormField — wraps Input/Select/Textarea with label, helper, error
- SearchInput — Input + search icon + clear button + results dropdown
- Card — surface container with header/body/footer slots
- Alert — info/success/warning/danger variants with dismiss support
- EmptyState — illustration, title, description, CTA slots
- Skeleton — text/circle/rectangle variants with shimmer animation

Token & font additions:
- fontFamilyDisplay token → "Unbounded" (Google Fonts, loaded in dev)
- --lucent-font-family-display CSS var auto-generated by makeLibraryCSS

Input fix:
- leftElement/rightElement slots now use textDisabled color when disabled
- Explicit disabled styles (bgMuted bg, transparent border, not-allowed cursor) replacing browser defaults

All molecules compose atoms and use the Text atom for all text rendering.