### PR TITLE
feat: GitHub launch polish — README, CONTRIBUTING, issue templates (closes #10)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,60 @@
+name: Bug report
+description: Something isn't working as expected
+labels: [type: bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. Please fill in as much detail as possible.
+
+  - type: input
+    id: component
+    attributes:
+      label: Component
+      placeholder: e.g. Button, FormField
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: A clear description of the bug.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect?
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Minimal reproduction
+      description: A code snippet or link to a sandbox that reproduces the issue.
+      render: tsx
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: lucent-ui version
+      placeholder: e.g. 0.1.0
+    validations:
+      required: true
+
+  - type: input
+    id: react_version
+    attributes:
+      label: React version
+      placeholder: e.g. 18.3.1
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Additional context
+      description: Screenshots, error messages, or anything else that might help.

--- a/.github/ISSUE_TEMPLATE/component_request.yml
+++ b/.github/ISSUE_TEMPLATE/component_request.yml
@@ -1,0 +1,66 @@
+name: Component request
+description: Propose a new component for the library
+labels: [type: feature, area: components]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before opening a request, check the [project board](https://github.com/users/rozinashopify/projects/3) to see if the component is already planned.
+
+  - type: input
+    id: name
+    attributes:
+      label: Component name
+      placeholder: e.g. Modal, DatePicker
+    validations:
+      required: true
+
+  - type: dropdown
+    id: tier
+    attributes:
+      label: Tier
+      description: Where does this component sit in the hierarchy?
+      options:
+        - atom (indivisible primitive)
+        - molecule (composed from atoms)
+        - block (page-section level)
+        - overlay (layers above content)
+        - flow (multi-step / stateful)
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: One-sentence description
+      description: Written for an AI audience — precise, not marketing copy.
+      placeholder: A modal dialog that interrupts the user to confirm a destructive action.
+    validations:
+      required: true
+
+  - type: textarea
+    id: use_cases
+    attributes:
+      label: Use cases
+      description: When would you reach for this component?
+    validations:
+      required: true
+
+  - type: textarea
+    id: props
+    attributes:
+      label: Proposed props (optional)
+      description: A rough sketch of the prop API.
+      render: ts
+
+  - type: textarea
+    id: design_intent
+    attributes:
+      label: Design intent (optional)
+      description: When to use each variant, when NOT to use this component, and any pairing rules.
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Additional context
+      description: Reference designs, similar components in other libraries, etc.

--- a/.github/ISSUE_TEMPLATE/manifest_feedback.yml
+++ b/.github/ISSUE_TEMPLATE/manifest_feedback.yml
@@ -1,0 +1,60 @@
+name: Manifest feedback
+description: A COMPONENT_MANIFEST is incorrect, incomplete, or misleading for AI tools
+labels: [type: manifest, area: ai]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        The manifest is what AI assistants use to generate code. If it's wrong, the AI will be wrong too.
+        Please be as specific as possible about what the manifest says vs. what it should say.
+
+  - type: input
+    id: component
+    attributes:
+      label: Component
+      placeholder: e.g. Button, FormField
+    validations:
+      required: true
+
+  - type: dropdown
+    id: field
+    attributes:
+      label: Affected field
+      options:
+        - props
+        - usageExamples
+        - designIntent
+        - compositionGraph
+        - description
+        - accessibility
+        - other
+    validations:
+      required: true
+
+  - type: textarea
+    id: current
+    attributes:
+      label: What the manifest currently says
+      render: ts
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What it should say
+      render: ts
+    validations:
+      required: true
+
+  - type: textarea
+    id: ai_impact
+    attributes:
+      label: How did this affect AI-generated output?
+      description: Paste any bad code the AI generated because of this manifest, if applicable.
+      render: tsx
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Additional context

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,122 @@
+# Contributing to Lucent UI
+
+Thanks for your interest in contributing! This document covers the process for adding components, fixing bugs, and improving the manifest spec.
+
+---
+
+## Project structure
+
+```
+src/
+  components/
+    atoms/<Name>/        # <Name>.tsx, <Name>.manifest.ts, index.ts
+    molecules/<Name>/    # same pattern
+  tokens/                # CSS custom property token system
+  provider/              # LucentProvider
+  index.ts               # root barrel export
+server/                  # MCP server
+docs/                    # spec and benchmarks
+```
+
+---
+
+## Getting started
+
+```bash
+# Fork and clone the repo
+git clone https://github.com/<your-username>/lucent-ui.git
+cd lucent-ui
+
+# Install dependencies (requires pnpm)
+pnpm install
+
+# Start the dev server
+pnpm dev
+```
+
+---
+
+## Adding a new component
+
+Every component must include three files:
+
+### 1. `<Name>.tsx`
+
+- Use inline styles + CSS custom properties only — no CSS-in-JS, no Tailwind
+- Source token values from `src/tokens/`; never hardcode colors or spacing
+- Use the `Text` atom for any text rendering
+- Disabled states use `bgMuted` / `textDisabled` / `transparent` border — no `opacity` hacks
+- Animated states use the spring easing: `cubic-bezier(0.34, 1.56, 0.64, 1)`
+
+### 2. `<Name>.manifest.ts`
+
+Every manifest must conform to `ComponentManifest` from `src/types/manifest.ts`.
+
+Required fields: `id`, `name`, `tier`, `domain`, `description`, `props`, `usageExamples`, `compositionGraph`, `designIntent`, `specVersion`.
+
+Key rules:
+- `id` is kebab-case, matches the export name in lowercase
+- `designIntent` is the most important field — explain when to use each variant, when *not* to use it, and any pairing constraints
+- `compositionGraph` is `[]` for atoms; molecules must list every atom they compose
+- `usageExamples` must include at minimum one default and one edge-case example
+
+See [`docs/COMPONENT_MANIFEST_SPEC.md`](docs/COMPONENT_MANIFEST_SPEC.md) for the full spec.
+
+### 3. `index.ts`
+
+```ts
+export { MyComponent } from './MyComponent';
+export { MyComponentManifest } from './MyComponent.manifest';
+```
+
+Then add both exports to `src/components/atoms/index.ts` (or `molecules/index.ts`).
+
+---
+
+## TypeScript
+
+The project uses `"exactOptionalPropertyTypes": true`. When forwarding optional props, use conditional spread:
+
+```ts
+// ✅ correct
+{...(prop !== undefined && { prop })}
+
+// ❌ wrong — fails with exactOptionalPropertyTypes
+{ prop }
+```
+
+---
+
+## Branch and PR conventions
+
+- Branch name: `issue/<number>-<short-slug>` (e.g. `issue/42-add-modal`)
+- One component or feature per PR
+- PR description should reference the issue: `closes #42`
+- CI must pass (type check + build + test) before merge
+
+---
+
+## Commit style
+
+Plain imperative sentences. Reference the issue where relevant.
+
+```
+feat: add Modal component (closes #42)
+fix: correct focus ring on Input in Firefox
+chore: update token for border-strong
+```
+
+---
+
+## Reporting issues
+
+Use the issue templates in `.github/ISSUE_TEMPLATE/`:
+- **Bug report** — something broken
+- **Component request** — new component proposal
+- **Manifest feedback** — incorrect or incomplete manifest
+
+---
+
+## Questions?
+
+Open a [GitHub Discussion](https://github.com/rozinashopify/lucent-ui/discussions) or file an issue.

--- a/README.md
+++ b/README.md
@@ -1,32 +1,37 @@
 # Lucent UI
 
 [![CI](https://github.com/rozinashopify/lucent-ui/actions/workflows/ci.yml/badge.svg)](https://github.com/rozinashopify/lucent-ui/actions/workflows/ci.yml)
+[![npm](https://img.shields.io/npm/v/lucent-ui)](https://www.npmjs.com/package/lucent-ui)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
 
-> An AI-first React component library. Every component ships with a machine-readable manifest so AI coding assistants generate correct, on-brand UI the first time.
+> **The React component library built for AI coding assistants.**
+> Every component ships with a machine-readable manifest — so Claude, Cursor, and Copilot generate correct, on-brand UI the first time, every time.
 
 ---
 
-## Status
+## Why Lucent UI?
 
-🚧 Under active development — see the [project board](https://github.com/users/rozinashopify/projects/3) for progress.
+AI tools generate UI from natural language. Without structure, they guess at prop names, invent variants that don't exist, and ignore design intent.
+
+Lucent UI solves this with `COMPONENT_MANIFEST` — a structured descriptor attached to every component and exposed via an **MCP server**. Your AI assistant calls `get_component_manifest("Button")` and gets back the full prop API, usage examples, and design intent. No more hallucinated props.
 
 ---
 
 ## Quick start
 
 ```bash
-# Install
 pnpm add lucent-ui
 ```
 
 ```tsx
-import { LucentProvider } from 'lucent-ui';
+import { LucentProvider, Button, Badge } from 'lucent-ui';
 import 'lucent-ui/styles';
 
-function App() {
+export default function App() {
   return (
     <LucentProvider>
-      {/* your app */}
+      <Button variant="primary">Get started</Button>
+      <Badge variant="success">Live</Badge>
     </LucentProvider>
   );
 }
@@ -34,23 +39,65 @@ function App() {
 
 ---
 
+## Components
+
+### Atoms
+| Component | Description |
+|-----------|-------------|
+| `Button` | Clickable control with `primary`, `secondary`, `ghost`, `danger` variants |
+| `Badge` | Inline status label |
+| `Avatar` | User avatar with image, initials, and icon fallback |
+| `Input` | Text input with label, helper text, and error state |
+| `Textarea` | Multi-line text input |
+| `Checkbox` | Controlled checkbox with spring animation |
+| `Radio` / `RadioGroup` | Radio button with group context |
+| `Toggle` | On/off switch |
+| `Select` | Native select with styled appearance |
+| `Tag` | Removable or static tag/chip |
+| `Tooltip` | Hover tooltip with placement options |
+| `Icon` | SVG icon wrapper (Lucide-compatible) |
+| `Text` | Polymorphic typography primitive (`p`, `h1`–`h6`, `span`, `code`, …) |
+| `Spinner` | Loading indicator |
+| `Divider` | Horizontal or vertical rule |
+
+### Molecules
+| Component | Description |
+|-----------|-------------|
+| `FormField` | Label + input + helper/error text composition |
+| `SearchInput` | Input with built-in search icon and clear button |
+| `Card` | Surface container with header, body, and footer slots |
+| `Alert` | Inline feedback banner (`info`, `success`, `warning`, `danger`) |
+| `EmptyState` | Zero-data placeholder with icon, title, and action |
+| `Skeleton` | Loading placeholder for content areas |
+
+---
+
 ## What is a COMPONENT_MANIFEST?
 
-Every component exports a machine-readable manifest describing its props, usage examples, composition graph, and design intent. This lets AI tools like Claude and Cursor generate correct, on-brand code without guessing.
+Every component exports a typed manifest describing its full API:
 
 ```ts
-import { Button, ButtonManifest } from 'lucent-ui';
+import { ButtonManifest } from 'lucent-ui';
 
 console.log(ButtonManifest);
 // {
 //   id: 'button',
 //   name: 'Button',
 //   tier: 'atom',
-//   props: [...],
+//   description: 'A clickable control that triggers an action.',
+//   props: [
+//     { name: 'variant', type: 'enum', enumValues: ['primary','secondary','ghost','danger'], ... },
+//     { name: 'size',    type: 'enum', enumValues: ['sm','md','lg'], ... },
+//     ...
+//   ],
 //   usageExamples: [...],
-//   designIntent: '...',
+//   designIntent: 'Use "primary" for the single most important action...',
+//   compositionGraph: [],
+//   specVersion: '0.1',
 // }
 ```
+
+See [`docs/COMPONENT_MANIFEST_SPEC.md`](docs/COMPONENT_MANIFEST_SPEC.md) for the full specification.
 
 ---
 
@@ -58,9 +105,11 @@ console.log(ButtonManifest);
 
 Connect Lucent UI's manifest layer to your AI coding tool. The server exposes three tools:
 
-- **`list_components`** — all component names + tiers
-- **`get_component_manifest(componentName)`** — full manifest JSON for a component
-- **`search_components(query)`** — components matching a description
+| Tool | Description |
+|------|-------------|
+| `list_components` | All component names and tiers |
+| `get_component_manifest(name)` | Full manifest JSON for a component |
+| `search_components(query)` | Components matching a natural-language description |
 
 ### Cursor
 
@@ -70,8 +119,7 @@ Connect Lucent UI's manifest layer to your AI coding tool. The server exposes th
   "mcpServers": {
     "lucent-ui": {
       "command": "npx",
-      "args": ["lucent-mcp"],
-      "env": { "LUCENT_API_KEY": "your-key" }
+      "args": ["lucent-mcp"]
     }
   }
 }
@@ -85,18 +133,44 @@ Connect Lucent UI's manifest layer to your AI coding tool. The server exposes th
   "mcpServers": {
     "lucent-ui": {
       "command": "npx",
-      "args": ["lucent-mcp"],
-      "env": { "LUCENT_API_KEY": "your-key" }
+      "args": ["lucent-mcp"]
     }
   }
 }
 ```
 
-### Run locally
+### Run locally (dev)
 
 ```bash
 node dist-server/server/index.js
 ```
+
+---
+
+## Theming
+
+Lucent UI uses CSS custom properties — no CSS-in-JS, no runtime overhead.
+
+```tsx
+import { LucentProvider, brandTokens } from 'lucent-ui';
+
+// Default neutral theme
+<LucentProvider>...</LucentProvider>
+
+// Built-in gold accent preset
+<LucentProvider tokens={brandTokens}>...</LucentProvider>
+
+// Fully custom
+<LucentProvider tokens={{ accentDefault: '#6366f1', accentHover: '#4f46e5' }}>
+  ...
+</LucentProvider>
+```
+
+---
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ---
 


### PR DESCRIPTION
## Summary
- **README** — hero tagline, Why section, component tables (15 atoms, 6 molecules), manifest code example, MCP setup snippets for Cursor + Claude Desktop, theming section
- **CONTRIBUTING.md** — project structure, adding a component (3-file pattern), manifest rules, TypeScript `exactOptionalPropertyTypes` gotcha, branch/commit conventions
- **Issue templates** (GitHub Forms YAML) — bug report, component request, manifest feedback

## Not included (manual step)
- Social preview image (1280×640) — needs to be designed and uploaded via **GitHub repo Settings → Social preview**

## Test plan
- [ ] Open a new issue and verify all three templates appear
- [ ] README renders correctly on GitHub
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)