### PR TITLE
fix(ci): add write permissions to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,10 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   release:
     name: Release


### PR DESCRIPTION
The Changesets Action needs to push a branch and open a PR, but `github-actions[bot]` was denied because the workflow had no explicit permissions.

Adds:
- `contents: write` — to push the `changeset-release/main` branch
- `pull-requests: write` — to open/update the "Version Packages" PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)