### PR TITLE
feat: Breadcrumb, Tabs, and Collapsible molecules

### DIFF
--- a/dev/ComponentPreview.tsx
+++ b/dev/ComponentPreview.tsx
@@ -21,6 +21,9 @@ import { Card } from '../src/components/molecules/Card/index.js';
 import { Alert } from '../src/components/molecules/Alert/index.js';
 import { EmptyState } from '../src/components/molecules/EmptyState/index.js';
 import { Skeleton } from '../src/components/molecules/Skeleton/index.js';
+import { Breadcrumb } from '../src/components/molecules/Breadcrumb/index.js';
+import { Tabs } from '../src/components/molecules/Tabs/index.js';
+import { Collapsible } from '../src/components/molecules/Collapsible/index.js';
 import type { LucentTokens, Theme } from '../src/index.js';
 
 type AccentPreset = 'default' | 'gold' | 'indigo';
@@ -636,6 +639,60 @@ function Inner({
             <span style={{ color: tokens.textSecondary, fontSize: tokens.fontSizeSm }}>About</span>
             <Divider orientation="vertical" />
             <span style={{ color: tokens.textSecondary, fontSize: tokens.fontSizeSm }}>Contact</span>
+          </div>
+        </Row>
+      </Section>
+
+      <Section title="Breadcrumb" tokens={tokens}>
+        <Row label="Default" tokens={tokens}>
+          <Breadcrumb
+            items={[
+              { label: 'Home', href: '#' },
+              { label: 'Settings', href: '#' },
+              { label: 'Profile' },
+            ]}
+          />
+        </Row>
+        <Row label="Custom separator" tokens={tokens}>
+          <Breadcrumb
+            separator="›"
+            items={[
+              { label: 'Dashboard', href: '#' },
+              { label: 'Projects', href: '#' },
+              { label: 'lucent-ui' },
+            ]}
+          />
+        </Row>
+      </Section>
+
+      <Section title="Tabs" tokens={tokens}>
+        <Row label="Default" tokens={tokens}>
+          <div style={{ width: '100%' }}>
+            <Tabs
+              tabs={[
+                { value: 'overview', label: 'Overview', content: <Text size="sm" color="secondary">Overview content goes here.</Text> },
+                { value: 'api', label: 'API', content: <Text size="sm" color="secondary">API reference content.</Text> },
+                { value: 'examples', label: 'Examples', content: <Text size="sm" color="secondary">Usage examples.</Text> },
+                { value: 'disabled', label: 'Disabled', content: null, disabled: true },
+              ]}
+            />
+          </div>
+        </Row>
+      </Section>
+
+      <Section title="Collapsible" tokens={tokens}>
+        <Row label="Default" tokens={tokens}>
+          <div style={{ width: '100%', maxWidth: 400, borderBottom: `1px solid ${tokens.borderDefault}` }}>
+            <Collapsible trigger={<Text weight="medium">Advanced options</Text>}>
+              <Text color="secondary">Hidden content that expands when you click the trigger above. Can contain any ReactNode.</Text>
+            </Collapsible>
+          </div>
+        </Row>
+        <Row label="Default open" tokens={tokens}>
+          <div style={{ width: '100%', maxWidth: 400, borderBottom: `1px solid ${tokens.borderDefault}` }}>
+            <Collapsible defaultOpen trigger={<Text weight="medium">Expanded by default</Text>}>
+              <Text color="secondary">This section starts expanded.</Text>
+            </Collapsible>
           </div>
         </Row>
       </Section>

--- a/src/components/molecules/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/molecules/Breadcrumb/Breadcrumb.tsx
@@ -1,0 +1,86 @@
+import type { CSSProperties, ReactNode } from 'react';
+import { Text } from '../../atoms/Text/index.js';
+
+export interface BreadcrumbItem {
+  label: ReactNode;
+  href?: string;
+  onClick?: () => void;
+}
+
+export interface BreadcrumbProps {
+  items: BreadcrumbItem[];
+  /** Separator between items. Defaults to "/" */
+  separator?: ReactNode;
+  style?: CSSProperties;
+}
+
+export function Breadcrumb({ items, separator = '/', style }: BreadcrumbProps) {
+  return (
+    <nav aria-label="Breadcrumb" style={style}>
+      <ol
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          flexWrap: 'wrap',
+          gap: 'var(--lucent-space-1)',
+          listStyle: 'none',
+          margin: 0,
+          padding: 0,
+          fontFamily: 'var(--lucent-font-family-base)',
+        }}
+      >
+        {items.map((item, i) => {
+          const isLast = i === items.length - 1;
+          return (
+            <li key={i} style={{ display: 'flex', alignItems: 'center', gap: 'var(--lucent-space-1)' }}>
+              {isLast ? (
+                <Text size="sm" color="primary" as="span" aria-current="page">
+                  {item.label}
+                </Text>
+              ) : item.href != null ? (
+                <a
+                  href={item.href}
+                  onClick={item.onClick}
+                  style={{
+                    fontSize: 'var(--lucent-font-size-sm)',
+                    color: 'var(--lucent-text-secondary)',
+                    textDecoration: 'none',
+                    fontFamily: 'var(--lucent-font-family-base)',
+                    transition: 'color var(--lucent-duration-fast) var(--lucent-easing-default)',
+                  }}
+                  onMouseEnter={(e) => { e.currentTarget.style.color = 'var(--lucent-text-primary)'; }}
+                  onMouseLeave={(e) => { e.currentTarget.style.color = 'var(--lucent-text-secondary)'; }}
+                >
+                  {item.label}
+                </a>
+              ) : (
+                <button
+                  onClick={item.onClick}
+                  style={{
+                    fontSize: 'var(--lucent-font-size-sm)',
+                    color: 'var(--lucent-text-secondary)',
+                    fontFamily: 'var(--lucent-font-family-base)',
+                    background: 'none',
+                    border: 'none',
+                    padding: 0,
+                    cursor: 'pointer',
+                    transition: 'color var(--lucent-duration-fast) var(--lucent-easing-default)',
+                  }}
+                  onMouseEnter={(e) => { e.currentTarget.style.color = 'var(--lucent-text-primary)'; }}
+                  onMouseLeave={(e) => { e.currentTarget.style.color = 'var(--lucent-text-secondary)'; }}
+                >
+                  {item.label}
+                </button>
+              )}
+              {!isLast && (
+                <span aria-hidden style={{ color: 'var(--lucent-text-disabled)', fontSize: 'var(--lucent-font-size-sm)', userSelect: 'none' }}>
+                  {separator}
+                </span>
+              )}
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}

--- a/src/components/molecules/Breadcrumb/index.ts
+++ b/src/components/molecules/Breadcrumb/index.ts
@@ -1,0 +1,1 @@
+export * from './Breadcrumb.js';

--- a/src/components/molecules/Collapsible/Collapsible.tsx
+++ b/src/components/molecules/Collapsible/Collapsible.tsx
@@ -1,0 +1,130 @@
+import { useState, useRef, useEffect, type CSSProperties, type ReactNode } from 'react';
+
+const STYLES = `
+@keyframes lucent-collapsible-open {
+  from { opacity: 0; transform: translateY(-4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+`;
+
+export interface CollapsibleProps {
+  trigger: ReactNode;
+  children: ReactNode;
+  defaultOpen?: boolean;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  style?: CSSProperties;
+}
+
+export function Collapsible({ trigger, children, defaultOpen = false, open, onOpenChange, style }: CollapsibleProps) {
+  const isControlled = open !== undefined;
+  const [internalOpen, setInternalOpen] = useState(defaultOpen);
+  const isOpen = isControlled ? open! : internalOpen;
+
+  const contentRef = useRef<HTMLDivElement>(null);
+  const [height, setHeight] = useState<number | undefined>(isOpen ? undefined : 0);
+  const animating = useRef(false);
+
+  // Animate height changes
+  useEffect(() => {
+    const el = contentRef.current;
+    if (!el) return;
+
+    if (isOpen) {
+      const scrollH = el.scrollHeight;
+      setHeight(scrollH);
+      animating.current = true;
+      const timer = setTimeout(() => {
+        setHeight(undefined); // remove fixed height so content can reflow
+        animating.current = false;
+      }, 220);
+      return () => clearTimeout(timer);
+    } else {
+      // Snapshot current height then collapse
+      setHeight(el.scrollHeight);
+      // Force reflow
+      el.getBoundingClientRect();
+      setHeight(0);
+    }
+  }, [isOpen]);
+
+  const toggle = () => {
+    const next = !isOpen;
+    if (!isControlled) setInternalOpen(next);
+    onOpenChange?.(next);
+  };
+
+  return (
+    <>
+      <style>{STYLES}</style>
+      <div style={{ display: 'flex', flexDirection: 'column', fontFamily: 'var(--lucent-font-family-base)', fontSize: 'var(--lucent-font-size-md)', ...style }}>
+        {/* Trigger button */}
+        <button
+          onClick={toggle}
+          aria-expanded={isOpen}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            width: '100%',
+            background: 'none',
+            border: 'none',
+            padding: 'var(--lucent-space-3) var(--lucent-space-4)',
+            cursor: 'pointer',
+            textAlign: 'left',
+            outline: 'none',
+            fontFamily: 'inherit',
+            fontSize: 'inherit',
+          }}
+        >
+          <span style={{ flex: 1 }}>{trigger}</span>
+          <CollapsibleChevron open={isOpen} />
+        </button>
+
+        {/* Animated content wrapper */}
+        <div
+          ref={contentRef}
+          aria-hidden={!isOpen}
+          style={{
+            overflow: 'hidden',
+            height: height !== undefined ? height : 'auto',
+            transition: 'height 200ms var(--lucent-easing-default)',
+          }}
+        >
+          <div
+            style={{
+              padding: 'var(--lucent-space-2) var(--lucent-space-4) var(--lucent-space-3)',
+              animation: isOpen ? 'lucent-collapsible-open 200ms var(--lucent-easing-default) forwards' : undefined,
+            }}
+          >
+            {children}
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}
+
+function CollapsibleChevron({ open }: { open: boolean }) {
+  return (
+    <svg
+      width={16}
+      height={16}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+      style={{
+        flexShrink: 0,
+        color: 'var(--lucent-text-secondary)',
+        transform: open ? 'rotate(180deg)' : 'rotate(0deg)',
+        transition: 'transform 200ms var(--lucent-easing-default)',
+      }}
+    >
+      <polyline points="6 9 12 15 18 9" />
+    </svg>
+  );
+}

--- a/src/components/molecules/Collapsible/index.ts
+++ b/src/components/molecules/Collapsible/index.ts
@@ -1,0 +1,1 @@
+export * from './Collapsible.js';

--- a/src/components/molecules/Tabs/Tabs.tsx
+++ b/src/components/molecules/Tabs/Tabs.tsx
@@ -1,0 +1,153 @@
+import { useState, useRef, useLayoutEffect, type CSSProperties, type ReactNode, type KeyboardEvent } from 'react';
+
+export interface TabItem {
+  value: string;
+  label: ReactNode;
+  content: ReactNode;
+  disabled?: boolean;
+}
+
+export interface TabsProps {
+  tabs: TabItem[];
+  defaultValue?: string;
+  value?: string;
+  onChange?: (value: string) => void;
+  style?: CSSProperties;
+}
+
+export function Tabs({ tabs, defaultValue, value, onChange, style }: TabsProps) {
+  const isControlled = value !== undefined;
+  const [internalValue, setInternalValue] = useState(defaultValue ?? tabs[0]?.value ?? '');
+  const activeValue = isControlled ? value! : internalValue;
+  const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
+
+  const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const [indicator, setIndicator] = useState<{ left: number; width: number; animate: boolean } | null>(null);
+  const mounted = useRef(false);
+
+  useLayoutEffect(() => {
+    const activeIdx = tabs.findIndex(t => t.value === activeValue);
+    const el = tabRefs.current[activeIdx];
+    if (!el) return;
+    setIndicator({ left: el.offsetLeft, width: el.offsetWidth, animate: mounted.current });
+    mounted.current = true;
+  }, [activeValue, tabs]);
+
+  const activate = (val: string) => {
+    if (!isControlled) setInternalValue(val);
+    onChange?.(val);
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLButtonElement>, idx: number) => {
+    const enabledIndexes = tabs.map((t, i) => (!t.disabled ? i : -1)).filter((i): i is number => i !== -1);
+    const pos = enabledIndexes.indexOf(idx);
+    let next = -1;
+    if (e.key === 'ArrowRight') next = enabledIndexes[(pos + 1) % enabledIndexes.length] ?? -1;
+    if (e.key === 'ArrowLeft') next = enabledIndexes[(pos - 1 + enabledIndexes.length) % enabledIndexes.length] ?? -1;
+    if (e.key === 'Home') next = enabledIndexes[0] ?? -1;
+    if (e.key === 'End') next = enabledIndexes[enabledIndexes.length - 1] ?? -1;
+    if (next !== -1) {
+      e.preventDefault();
+      tabRefs.current[next]?.focus();
+      activate(tabs[next]!.value);
+    }
+  };
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', ...style }}>
+      {/* Tab list */}
+      <div
+        role="tablist"
+        style={{
+          position: 'relative',
+          display: 'flex',
+          borderBottom: '1px solid var(--lucent-border-default)',
+        }}
+      >
+        {tabs.map((tab, i) => {
+          const isActive = tab.value === activeValue;
+          const isDisabled = tab.disabled ?? false;
+          return (
+            <button
+              key={tab.value}
+              ref={(el) => { tabRefs.current[i] = el; }}
+              role="tab"
+              aria-selected={isActive}
+              aria-controls={`lucent-tabpanel-${tab.value}`}
+              id={`lucent-tab-${tab.value}`}
+              disabled={isDisabled}
+              tabIndex={isActive ? 0 : -1}
+              onClick={() => { if (!isDisabled) activate(tab.value); }}
+              onKeyDown={(e) => handleKeyDown(e, i)}
+              onMouseEnter={() => { if (!isDisabled) setHoveredIndex(i); }}
+              onMouseLeave={() => setHoveredIndex(null)}
+              style={{
+                padding: 'var(--lucent-space-1) var(--lucent-space-2) var(--lucent-space-3)',
+                background: 'none',
+                border: 'none',
+                cursor: isDisabled ? 'not-allowed' : 'pointer',
+                fontFamily: 'var(--lucent-font-family-base)',
+                fontSize: 'var(--lucent-font-size-md)',
+                fontWeight: isActive ? 'var(--lucent-font-weight-medium)' : 'var(--lucent-font-weight-regular)',
+                color: isDisabled
+                  ? 'var(--lucent-text-disabled)'
+                  : isActive
+                  ? 'var(--lucent-text-primary)'
+                  : 'var(--lucent-text-secondary)',
+                transition: 'color var(--lucent-duration-fast) var(--lucent-easing-default)',
+                whiteSpace: 'nowrap',
+                outline: 'none',
+              }}
+            >
+              <span style={{
+                display: 'block',
+                padding: 'var(--lucent-space-1) var(--lucent-space-3)',
+                borderRadius: 'var(--lucent-radius-md)',
+                background: hoveredIndex === i && !isActive
+                  ? 'var(--lucent-bg-subtle)'
+                  : 'transparent',
+                transition: 'background var(--lucent-duration-fast) var(--lucent-easing-default)',
+              }}>
+                {tab.label}
+              </span>
+            </button>
+          );
+        })}
+
+        {/* Sliding indicator */}
+        {indicator != null && (
+          <span
+            aria-hidden
+            style={{
+              position: 'absolute',
+              bottom: 0,
+              left: indicator.left,
+              width: indicator.width,
+              height: 2,
+              background: 'var(--lucent-accent-default)',
+              borderRadius: 'var(--lucent-radius-sm)',
+              transition: indicator.animate
+                ? 'left 220ms var(--lucent-easing-default), width 220ms var(--lucent-easing-default)'
+                : 'none',
+            }}
+          />
+        )}
+      </div>
+
+      {/* Tab panels */}
+      {tabs.map((tab) => (
+        <div
+          key={tab.value}
+          role="tabpanel"
+          id={`lucent-tabpanel-${tab.value}`}
+          aria-labelledby={`lucent-tab-${tab.value}`}
+          hidden={tab.value !== activeValue}
+          style={{ padding: 'var(--lucent-space-4) 0', outline: 'none' }}
+          tabIndex={0}
+        >
+          {tab.content}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/molecules/Tabs/index.ts
+++ b/src/components/molecules/Tabs/index.ts
@@ -1,0 +1,1 @@
+export * from './Tabs.js';

--- a/src/components/molecules/index.ts
+++ b/src/components/molecules/index.ts
@@ -4,3 +4,6 @@ export * from './Card/index.js';
 export * from './Alert/index.js';
 export * from './EmptyState/index.js';
 export * from './Skeleton/index.js';
+export * from './Breadcrumb/index.js';
+export * from './Tabs/index.js';
+export * from './Collapsible/index.js';


### PR DESCRIPTION
## Summary

- **Breadcrumb** (#38) — supports `href`, `onClick`, or plain text per item; hover colour transition on non-active items
- **Tabs** (#35) — animated sliding indicator, keyboard navigation (Arrow/Home/End), controlled + uncontrolled, per-tab `disabled`
- **Collapsible** (#36) — animated height open/close, rotating chevron, controlled + uncontrolled

## Notes

- `CopyButton` was considered but dropped — it's a one-liner pattern on top of `Button`, not a library component
- Tabs indicator uses `useLayoutEffect` to measure position synchronously (no flash on first render)

## Test plan

- [ ] Breadcrumb renders links, buttons, and plain text items correctly
- [ ] Breadcrumb hover colour transitions work
- [ ] Tabs sliding indicator animates between tabs
- [ ] Tabs keyboard navigation (ArrowLeft/Right, Home, End) works
- [ ] Tabs disabled tab is non-interactive
- [ ] Collapsible animates open/close
- [ ] Collapsible chevron rotates on toggle
- [ ] Collapsible controlled and uncontrolled modes work
- [ ] All components type-check cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)