### PR TITLE
chore: version packages (v0.2.0)

### DIFF
--- a/.changeset/new-components-wave-3.md
+++ b/.changeset/new-components-wave-3.md
@@ -1,0 +1,5 @@
+---
+"lucent-ui": minor
+---
+
+Add Breadcrumb, Tabs, Collapsible, NavLink, and PageLayout components


### PR DESCRIPTION
## Summary

- Adds changeset for a `minor` version bump (`0.1.1` → `0.2.0`)
- Covers the two recent component waves merged in PRs #45 and #46:
  - Breadcrumb, Tabs, Collapsible (Group A)
  - NavLink, PageLayout (Group B)

## What happens on merge

The release workflow will pick up the changeset, bump `package.json` to `0.2.0`, update `CHANGELOG.md`, and publish to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)