### PR TITLE
feat(manifest): COMPONENT_MANIFEST spec v1.0 — JSON Schema + migration guide

### DIFF
--- a/docs/COMPONENT_MANIFEST_MIGRATION.md
+++ b/docs/COMPONENT_MANIFEST_MIGRATION.md
@@ -1,0 +1,300 @@
+# COMPONENT_MANIFEST Migration Guide
+
+> How to add `COMPONENT_MANIFEST` exports to an existing component library — shadcn/ui, MUI, Radix, or your own system.
+
+This guide targets library authors and design system maintainers. By the end, every component in your library will export a typed, machine-readable manifest that AI tools can consume directly.
+
+**Spec reference:** [COMPONENT_MANIFEST_SPEC.md](./COMPONENT_MANIFEST_SPEC.md)
+**JSON Schema:** [component-manifest.schema.json](./component-manifest.schema.json)
+
+---
+
+## Why bother?
+
+AI coding assistants (Claude, Cursor, Copilot) generate UI code without knowing your component API. They invent prop names, use variants that don't exist, and ignore your design intent. A `COMPONENT_MANIFEST` gives them structured, trustworthy context — the same way OpenAPI does for REST APIs.
+
+Once your manifests are in place, you can:
+- Point an MCP server at them so Claude knows your component API by default
+- Generate documentation automatically
+- Lint AI-generated code against your actual API
+- Validate manifests in CI
+
+---
+
+## Step 1 — Install the types
+
+The manifest types are published as part of `lucent-ui`. Install it as a dev dependency — you only need the types, the runtime components are tree-shaken away:
+
+```bash
+# npm
+npm add -D lucent-ui
+
+# pnpm
+pnpm add -D lucent-ui
+
+# yarn
+yarn add -D lucent-ui
+```
+
+---
+
+## Step 2 — Create your first manifest
+
+Co-locate a `.manifest.ts` file alongside each component:
+
+```
+src/
+  components/
+    Button/
+      Button.tsx          ← your existing component
+      Button.manifest.ts  ← new file
+      index.ts
+```
+
+**`Button.manifest.ts`:**
+
+```ts
+import type { ComponentManifest } from 'lucent-ui';
+
+export const ButtonManifest: ComponentManifest = {
+  id: 'button',
+  name: 'Button',
+  tier: 'atom',
+  domain: 'neutral',
+  specVersion: '1.0',
+  description: 'A clickable control that triggers an action.',
+  designIntent:
+    'Use "primary" for the single most important action in a view. ' +
+    'Use "danger" exclusively for destructive operations. ' +
+    'Reserve "ghost" for low-emphasis actions in dense UIs.',
+  props: [
+    {
+      name: 'variant',
+      type: 'enum',
+      required: false,
+      default: 'primary',
+      description: 'Visual style conveying action hierarchy.',
+      enumValues: ['primary', 'secondary', 'ghost', 'danger'],
+    },
+    {
+      name: 'children',
+      type: 'ReactNode',
+      required: true,
+      description: 'Button label or content.',
+    },
+    {
+      name: 'disabled',
+      type: 'boolean',
+      required: false,
+      default: 'false',
+      description: 'Prevents interaction and applies disabled styling.',
+    },
+  ],
+  usageExamples: [
+    {
+      title: 'Primary action',
+      code: `<Button variant="primary" onClick={handleSave}>Save changes</Button>`,
+    },
+    {
+      title: 'Destructive action',
+      code: `<Button variant="danger" onClick={handleDelete}>Delete account</Button>`,
+      description: 'Use "danger" only for irreversible operations.',
+    },
+  ],
+  compositionGraph: [],
+  accessibility: {
+    role: 'button',
+    ariaAttributes: ['aria-disabled', 'aria-busy'],
+    keyboardInteractions: ['Enter — activates the button', 'Space — activates the button'],
+  },
+};
+```
+
+Export it from your component's `index.ts`:
+
+```ts
+export { Button } from './Button';
+export { ButtonManifest } from './Button.manifest';
+```
+
+---
+
+## Step 3 — Validate in your test suite
+
+Add a test that asserts every manifest is valid before you ship:
+
+```ts
+// Button.manifest.test.ts
+import { assertManifest } from 'lucent-ui';
+import { ButtonManifest } from './Button.manifest';
+
+test('ButtonManifest is valid', () => {
+  // Throws with a descriptive message if the manifest is invalid
+  assertManifest(ButtonManifest);
+});
+```
+
+Or use `validateManifest` when you need the error list without throwing:
+
+```ts
+import { validateManifest } from 'lucent-ui';
+import { ButtonManifest } from './Button.manifest';
+
+test('ButtonManifest is valid', () => {
+  const result = validateManifest(ButtonManifest);
+  expect(result.valid).toBe(true);
+  expect(result.errors).toHaveLength(0);
+});
+```
+
+---
+
+## Step 4 — Validate against JSON Schema (optional, CI)
+
+For language-agnostic validation (e.g. in a non-TypeScript repo or CI pipeline):
+
+```bash
+npm install -g ajv-cli
+
+# Compile your manifest to JSON first, then validate
+ajv validate \
+  -s node_modules/lucent-ui/docs/component-manifest.schema.json \
+  -d path/to/button.manifest.json
+```
+
+Or reference the schema directly in your manifest JSON via `$schema`:
+
+```json
+{
+  "$schema": "https://lucentui.ai/spec/component-manifest.schema.json",
+  "id": "button",
+  "name": "Button",
+  ...
+}
+```
+
+---
+
+## Library-specific notes
+
+### shadcn/ui
+
+shadcn components are copied into your project (`components/ui/`), not imported from a package. Add a `.manifest.ts` next to each copied component file.
+
+The `tier` for most shadcn components:
+- `button`, `badge`, `avatar`, `input`, `checkbox` → `"atom"`
+- `card`, `alert`, `dialog`, `form` → `"molecule"`
+- `navigation-menu`, `sidebar` → `"block"`
+- `sheet`, `drawer`, `popover`, `tooltip` → `"overlay"`
+
+Use `domain: "neutral"` for all shadcn primitives.
+
+**Example structure:**
+
+```
+components/
+  ui/
+    button.tsx           ← shadcn component (unchanged)
+    button.manifest.ts   ← your manifest
+```
+
+Because shadcn components have a fixed, documented API, you can write manifests by reading the Radix/shadcn docs — you don't need to reverse-engineer the source.
+
+### MUI (Material UI)
+
+MUI components are imported from `@mui/material`. You won't co-locate manifests inside `node_modules`. Instead, maintain a separate `manifests/` directory in your project:
+
+```
+src/
+  manifests/
+    mui-button.manifest.ts
+    mui-text-field.manifest.ts
+    index.ts
+```
+
+Use the MUI component's public prop API (from their docs/TypeScript types) to fill in `props`. Set `domain: "neutral"` for core MUI components, or your product domain for custom wrappers.
+
+**Tip:** If you wrap MUI components, export manifests from the wrapper component's folder instead.
+
+### Radix UI
+
+Radix primitives are headless — your actual component is the styled wrapper. The manifest should describe your wrapper's API, not Radix's internal API.
+
+For compound components (e.g. `Dialog.Root` + `Dialog.Trigger` + `Dialog.Content`), write one manifest for the composed whole, not each part:
+
+```ts
+export const DialogManifest: ComponentManifest = {
+  id: 'dialog',
+  name: 'Dialog',
+  tier: 'overlay',
+  ...
+  compositionGraph: [
+    { componentId: 'button', componentName: 'Button', role: 'trigger', required: false },
+  ],
+};
+```
+
+### Your own design system
+
+If your library already exports TypeScript prop types, you can auto-generate the `props` array from them using a build script. The manifest's `type` field accepts any string, so mapping from your TypeScript types is straightforward.
+
+A minimal build script pattern:
+
+```ts
+// scripts/generate-manifests.ts
+import ts from 'typescript';
+// ... parse your component's Props interface and emit PropDescriptor[]
+```
+
+---
+
+## Tier reference
+
+| Tier | Description | Examples |
+|---|---|---|
+| `atom` | Indivisible primitive | Button, Input, Badge, Checkbox |
+| `molecule` | Composed from atoms | FormField, Card, Alert, SearchInput |
+| `block` | Page-section level | PageHeader, SidebarNav, DataTable |
+| `flow` | Multi-step / stateful | Wizard, Onboarding, StepForm |
+| `overlay` | Layers above content | Modal, Drawer, Tooltip, Popover |
+
+When in doubt: if a component uses other components internally, it's at least a `molecule`.
+
+---
+
+## designIntent — the most important field
+
+This is what separates a useful manifest from a useless one. AI tools already know what a `variant: "primary"` prop looks like — they don't know *when* to use it.
+
+Write `designIntent` as if explaining the component to a new engineer on their first day:
+
+```ts
+// Bad — restates the prop API
+designIntent: 'The variant prop controls the visual style of the button.'
+
+// Good — explains the design decisions
+designIntent:
+  'Use "primary" for the single most important action in a view — there should be ' +
+  'at most one primary button per screen section. "secondary" is for supporting ' +
+  'actions that appear alongside a primary. Use "ghost" in toolbars and table rows ' +
+  'where a full button background would create visual noise. "danger" is reserved ' +
+  'exclusively for destructive, irreversible operations — never use it for warnings.'
+```
+
+---
+
+## Checklist
+
+Before shipping manifests for a component:
+
+- [ ] `id` is kebab-case and unique within your library
+- [ ] `specVersion` is `"1.0"`
+- [ ] `props` covers the full public API (required and commonly-used optional props)
+- [ ] `usageExamples` has at least 2 examples (default + edge case)
+- [ ] `designIntent` explains *when* to use each variant/option, not just what it does
+- [ ] `compositionGraph` is `[]` for atoms, populated for molecules and above
+- [ ] `assertManifest()` passes in your test suite
+
+---
+
+*Questions or feedback? Open an issue at [github.com/rozina-hudson/lucent-ui](https://github.com/rozina-hudson/lucent-ui/issues).*

--- a/docs/COMPONENT_MANIFEST_SPEC.md
+++ b/docs/COMPONENT_MANIFEST_SPEC.md
@@ -1,12 +1,18 @@
-# COMPONENT_MANIFEST Spec v0.1
+# COMPONENT_MANIFEST Spec v1.0
 
-> A machine-readable description of a UI component, designed to give AI coding assistants the context they need to generate correct, on-brand code.
+> **COMPONENT_MANIFEST_SPEC@1.0.0** — A machine-readable description of a UI component, designed to give AI coding assistants the context they need to generate correct, on-brand code.
+
+**Status:** Stable
+**JSON Schema:** [component-manifest.schema.json](./component-manifest.schema.json) · published at `https://lucentui.ai/spec/component-manifest.schema.json`
+**Migration guide:** [COMPONENT_MANIFEST_MIGRATION.md](./COMPONENT_MANIFEST_MIGRATION.md)
 
 ---
 
 ## Motivation
 
-AI tools like Claude, Cursor, and Copilot generate UI code from natural language. Without structured context, they guess at prop names, invent variants that don't exist, and ignore design intent. `COMPONENT_MANIFEST` solves this by attaching a rich, structured descriptor to every component — consumed directly by an MCP server.
+AI tools like Claude, Cursor, and Copilot generate UI code from natural language. Without structured context, they guess at prop names, invent variants that don't exist, and ignore design intent. `COMPONENT_MANIFEST` solves this by attaching a rich, structured descriptor to every component — consumed directly by an MCP server or any compatible tooling.
+
+The spec is library-agnostic. Any component library — shadcn/ui, MUI, Radix, your in-house system — can export manifests conforming to this standard.
 
 ---
 
@@ -20,11 +26,11 @@ interface ComponentManifest {
   domain:           string;               // "neutral" or product domain
   description:      string;               // one-sentence summary
   props:            PropDescriptor[];     // full prop API
-  usageExamples:    UsageExample[];       // copy-paste code snippets
-  compositionGraph: CompositionNode[];    // sub-components (empty for atoms)
+  usageExamples:    UsageExample[];       // copy-paste code snippets (≥1 required)
+  compositionGraph: CompositionNode[];    // sub-components (empty [] for atoms)
   designIntent:     string;               // the "why" behind visual/interaction decisions
   accessibility?:   AccessibilityDescriptor;
-  specVersion:      string;               // "MAJOR.MINOR"
+  specVersion:      string;               // "MAJOR.MINOR" — currently "1.0"
 }
 ```
 
@@ -33,10 +39,12 @@ interface ComponentManifest {
 ## Fields
 
 ### `id`
-Kebab-case unique identifier. Used by the MCP server for lookups.
+Kebab-case unique identifier. Used by the MCP server and tooling for lookups.
 ```
 "button" | "form-field" | "data-table"
 ```
+
+Pattern: `^[a-z][a-z0-9-]*$`
 
 ### `name`
 Display name shown in documentation and tooling.
@@ -63,17 +71,19 @@ Full prop API. Each `PropDescriptor`:
 
 ```ts
 interface PropDescriptor {
-  name:        string;
-  type:        PropType;       // "string" | "boolean" | "enum" | "ReactNode" | …
-  required:    boolean;
-  default?:    string;         // string representation of default value
-  description: string;
-  enumValues?: string[];       // for type: "enum"
+  name:         string;
+  type:         PropType;       // "string" | "boolean" | "enum" | "ReactNode" | …
+  required:     boolean;
+  default?:     string;         // string representation of default value
+  description:  string;
+  enumValues?:  string[];       // required when type is "enum"
 }
 ```
 
+**`PropType` well-known values:** `"string"`, `"number"`, `"boolean"`, `"ReactNode"`, `"function"`, `"enum"`, `"object"`, `"array"`, `"ref"`. Custom type names (e.g. `"ButtonVariant"`) are also valid.
+
 ### `usageExamples`
-Code strings an AI can use directly. At minimum: one default usage + one edge case.
+Code strings an AI can use directly. **At minimum: one default usage + one edge case.**
 
 ```ts
 interface UsageExample {
@@ -84,18 +94,16 @@ interface UsageExample {
 ```
 
 ### `compositionGraph`
-For molecules and above — the sub-components this component uses:
+For molecules and above — the sub-components this component uses. Atoms always set `compositionGraph: []`.
 
 ```ts
 interface CompositionNode {
-  componentId:   string;
+  componentId:   string;   // kebab-case id of the sub-component
   componentName: string;
-  role:          string;   // how it's used
+  role:          string;   // how it's used in this composition
   required:      boolean;
 }
 ```
-
-Atoms always have an empty `compositionGraph: []`.
 
 ### `designIntent`
 **The most important field for AI-legibility.** Explain:
@@ -108,7 +116,7 @@ Example:
 > "Use 'primary' for the single most important action in a view. Use 'danger' exclusively for destructive or irreversible operations — never for warnings."
 
 ### `accessibility`
-Optional but recommended:
+Optional but strongly recommended:
 
 ```ts
 interface AccessibilityDescriptor {
@@ -120,11 +128,23 @@ interface AccessibilityDescriptor {
 ```
 
 ### `specVersion`
-`"MAJOR.MINOR"` — currently `"0.1"`. Consumers should check this field when parsing manifests.
+`"MAJOR.MINOR"` — currently `"1.0"`. Consumers must check this field when parsing manifests. Manifests with a `0.x` version should be treated as pre-stable.
 
 ---
 
-## Validation
+## JSON Schema validation
+
+A JSON Schema (draft-07) is published alongside this spec. Use it to validate any manifest:
+
+```bash
+# Install a JSON Schema validator
+npm install -g ajv-cli
+
+# Validate your manifest
+ajv validate -s docs/component-manifest.schema.json -d my-manifest.json
+```
+
+Or programmatically via the Lucent UI runtime validator:
 
 ```ts
 import { validateManifest, assertManifest } from 'lucent-ui';
@@ -148,7 +168,7 @@ export const ButtonManifest: ComponentManifest = {
   name: 'Button',
   tier: 'atom',
   domain: 'neutral',
-  specVersion: '0.1',
+  specVersion: '1.0',
   description: 'A clickable control that triggers an action.',
   designIntent:
     'Use "primary" for the single most important action. Use "danger" exclusively ' +
@@ -162,15 +182,36 @@ export const ButtonManifest: ComponentManifest = {
       description: 'Visual style conveying action hierarchy.',
       enumValues: ['primary', 'secondary', 'ghost', 'danger'],
     },
-    // …
+    {
+      name: 'children',
+      type: 'ReactNode',
+      required: true,
+      description: 'Button label or content.',
+    },
+    {
+      name: 'disabled',
+      type: 'boolean',
+      required: false,
+      default: 'false',
+      description: 'Prevents interaction and applies disabled styling.',
+    },
   ],
   usageExamples: [
     {
       title: 'Primary action',
       code: `<Button variant="primary" onClick={handleSave}>Save changes</Button>`,
     },
+    {
+      title: 'Destructive action',
+      code: `<Button variant="danger" onClick={handleDelete}>Delete account</Button>`,
+    },
   ],
   compositionGraph: [],
+  accessibility: {
+    role: 'button',
+    ariaAttributes: ['aria-disabled', 'aria-busy'],
+    keyboardInteractions: ['Enter — activates the button', 'Space — activates the button'],
+  },
 };
 ```
 
@@ -178,12 +219,13 @@ export const ButtonManifest: ComponentManifest = {
 
 ## Adopting this spec in your own library
 
-1. Install the types: `pnpm add -D lucent-ui` (types only — tree-shake the rest)
+See the full [Migration Guide](./COMPONENT_MANIFEST_MIGRATION.md) for step-by-step instructions for shadcn/ui, MUI, Radix, and other libraries.
+
+Quick start:
+1. Install the types: `npm add -D lucent-ui` (types only — tree-shake the rest)
 2. Add a `COMPONENT_MANIFEST` export alongside each component
 3. Use `validateManifest()` in your test suite to enforce spec compliance
 4. Optionally: run your own MCP server pointing at your manifests
-
-See [lucentui.ai/spec](https://lucentui.ai/spec) for the full versioned specification.
 
 ---
 
@@ -191,7 +233,30 @@ See [lucentui.ai/spec](https://lucentui.ai/spec) for the full versioned specific
 
 | Version | Status | Notes |
 |---|---|---|
-| 0.1 | Current | Initial spec — may change before 1.0 |
-| 1.0 | Planned | Stable, JSON Schema published |
+| 0.1 | Superseded | Initial draft — pre-stable |
+| 1.0 | **Current (stable)** | Stable API, JSON Schema published, migration guide available |
 
-Breaking changes will increment the major version. Additive changes increment minor.
+Breaking changes increment the major version. Additive changes increment minor. Manifests must set `specVersion` to the version of this spec they conform to.
+
+### What changed from 0.1 → 1.0
+
+- `specVersion` field bumped from `"0.1"` to `"1.0"`
+- JSON Schema published alongside spec (draft-07, `$id` points to `lucentui.ai/spec`)
+- `usageExamples` minimum count of 1 is now enforced in schema (was previously documented-only)
+- `compositionGraph[].componentId` now enforces kebab-case pattern in schema
+- `PropDescriptor.enumValues` minimum of 1 item enforced when present
+- All `additionalProperties: false` — unknown keys now fail schema validation
+- Migration guide added for shadcn/ui, MUI, and Radix
+
+### Migration from 0.1 → 1.0
+
+No TypeScript interface changes. The only required code change is:
+
+```diff
+- specVersion: '0.1',
++ specVersion: '1.0',
+```
+
+---
+
+*Maintained by [Lucent UI](https://github.com/rozina-hudson/lucent-ui). Issues and feedback welcome.*

--- a/docs/component-manifest.schema.json
+++ b/docs/component-manifest.schema.json
@@ -1,0 +1,181 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://lucentui.ai/spec/component-manifest.schema.json",
+  "title": "ComponentManifest",
+  "description": "COMPONENT_MANIFEST Spec v1.0.0 — machine-readable descriptor for a UI component, designed for AI coding assistants and design system tooling.",
+  "type": "object",
+  "required": ["id", "name", "tier", "domain", "description", "props", "usageExamples", "compositionGraph", "designIntent", "specVersion"],
+  "additionalProperties": false,
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Kebab-case unique identifier used by tooling for lookups.",
+      "pattern": "^[a-z][a-z0-9-]*$",
+      "examples": ["button", "form-field", "data-table"]
+    },
+    "name": {
+      "type": "string",
+      "description": "Display name shown in documentation and tooling.",
+      "minLength": 1,
+      "examples": ["Button", "FormField", "DataTable"]
+    },
+    "tier": {
+      "type": "string",
+      "description": "Position of the component in the design system hierarchy.",
+      "enum": ["atom", "molecule", "block", "flow", "overlay"]
+    },
+    "domain": {
+      "type": "string",
+      "description": "Product domain this component belongs to. Use \"neutral\" for general-purpose components.",
+      "minLength": 1,
+      "examples": ["neutral", "billing", "auth", "onboarding"]
+    },
+    "description": {
+      "type": "string",
+      "description": "One-sentence description written for an AI audience — precise, not marketing copy.",
+      "minLength": 1
+    },
+    "props": {
+      "type": "array",
+      "description": "Full prop API for the component.",
+      "items": { "$ref": "#/$defs/PropDescriptor" }
+    },
+    "usageExamples": {
+      "type": "array",
+      "description": "Code examples an AI can use to generate correct usage. Must include at least one.",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/UsageExample" }
+    },
+    "compositionGraph": {
+      "type": "array",
+      "description": "Sub-components this component is composed from. Atoms must use an empty array.",
+      "items": { "$ref": "#/$defs/CompositionNode" }
+    },
+    "designIntent": {
+      "type": "string",
+      "description": "The 'why' behind visual and interaction decisions. The key field for AI-legibility — conveys context that prop types alone cannot.",
+      "minLength": 1
+    },
+    "accessibility": { "$ref": "#/$defs/AccessibilityDescriptor" },
+    "specVersion": {
+      "type": "string",
+      "description": "Spec version this manifest conforms to. Format: MAJOR.MINOR (e.g. \"1.0\").",
+      "pattern": "^\\d+\\.\\d+$",
+      "examples": ["1.0"]
+    }
+  },
+  "$defs": {
+    "PropDescriptor": {
+      "type": "object",
+      "description": "Describes a single prop in a component's public API.",
+      "required": ["name", "type", "required", "description"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Prop name as it appears in the component API.",
+          "minLength": 1
+        },
+        "type": {
+          "type": "string",
+          "description": "TypeScript type or well-known type name.",
+          "minLength": 1,
+          "examples": ["string", "number", "boolean", "ReactNode", "function", "enum", "object", "array", "ref"]
+        },
+        "required": {
+          "type": "boolean",
+          "description": "Whether the prop is required."
+        },
+        "default": {
+          "type": "string",
+          "description": "Default value as a string representation (e.g. \"false\", \"\\\"primary\\\"\")."
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description for AI and documentation.",
+          "minLength": 1
+        },
+        "enumValues": {
+          "type": "array",
+          "description": "Allowed values when type is \"enum\".",
+          "items": { "type": "string" },
+          "minItems": 1
+        }
+      }
+    },
+    "UsageExample": {
+      "type": "object",
+      "description": "A copy-paste code snippet demonstrating component usage.",
+      "required": ["title", "code"],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string",
+          "description": "Short label identifying this example.",
+          "minLength": 1
+        },
+        "code": {
+          "type": "string",
+          "description": "JSX or TSX code string.",
+          "minLength": 1
+        },
+        "description": {
+          "type": "string",
+          "description": "Optional description of what this example demonstrates."
+        }
+      }
+    },
+    "CompositionNode": {
+      "type": "object",
+      "description": "A sub-component used in the composition of this component.",
+      "required": ["componentId", "componentName", "role", "required"],
+      "additionalProperties": false,
+      "properties": {
+        "componentId": {
+          "type": "string",
+          "description": "The id of the sub-component (kebab-case).",
+          "pattern": "^[a-z][a-z0-9-]*$"
+        },
+        "componentName": {
+          "type": "string",
+          "description": "Human-readable name of the sub-component.",
+          "minLength": 1
+        },
+        "role": {
+          "type": "string",
+          "description": "How this sub-component is used in the composition.",
+          "minLength": 1
+        },
+        "required": {
+          "type": "boolean",
+          "description": "Whether this sub-component is always present (true) or conditional (false)."
+        }
+      }
+    },
+    "AccessibilityDescriptor": {
+      "type": "object",
+      "description": "Accessibility metadata for the component.",
+      "additionalProperties": false,
+      "properties": {
+        "role": {
+          "type": "string",
+          "description": "ARIA role applied to the root element."
+        },
+        "ariaAttributes": {
+          "type": "array",
+          "description": "ARIA attributes used by this component.",
+          "items": { "type": "string" }
+        },
+        "keyboardInteractions": {
+          "type": "array",
+          "description": "Keyboard interactions supported by this component.",
+          "items": { "type": "string" }
+        },
+        "notes": {
+          "type": "string",
+          "description": "Plain-English notes for screen reader behaviour."
+        }
+      }
+    }
+  }
+}

--- a/src/manifest/examples/button.manifest.ts
+++ b/src/manifest/examples/button.manifest.ts
@@ -5,7 +5,7 @@ export const ButtonManifest: ComponentManifest = {
   name: 'Button',
   tier: 'atom',
   domain: 'neutral',
-  specVersion: '0.1',
+  specVersion: '1.0',
   description:
     'A clickable control that triggers an action. The primary interactive primitive in Lucent UI.',
   designIntent:

--- a/src/manifest/index.ts
+++ b/src/manifest/index.ts
@@ -19,4 +19,4 @@ export type { ValidationResult, ValidationError } from './validate.js';
 
 export { ButtonManifest } from './examples/button.manifest.js';
 
-export const MANIFEST_SPEC_VERSION = '0.1';
+export const MANIFEST_SPEC_VERSION = '1.0';


### PR DESCRIPTION
## Summary

- Publishes `COMPONENT_MANIFEST_SPEC@1.0.0` as a stable, versioned standard
- Ships a JSON Schema (draft-07) at `docs/component-manifest.schema.json` — `$id` targets `lucentui.ai/spec/component-manifest.schema.json`; `additionalProperties: false` throughout, enforces kebab-case ids, pattern-validated `specVersion`, min 1 usage example
- Updates `docs/COMPONENT_MANIFEST_SPEC.md` to v1.0 with changelog, one-line 0.1→1.0 migration diff, and links to schema and migration guide
- Adds `docs/COMPONENT_MANIFEST_MIGRATION.md` — step-by-step adoption guide for shadcn/ui, MUI, and Radix; covers file layout, test validation, CI JSON Schema validation, `designIntent` guidance, and a pre-ship checklist
- Bumps `MANIFEST_SPEC_VERSION` constant and `ButtonManifest.specVersion` to `'1.0'`

## Test plan

- [ ] `npx tsc --noEmit` passes (verified clean)
- [ ] Review `docs/component-manifest.schema.json` — validate Button manifest JSON against it manually
- [ ] Review migration guide for accuracy against shadcn/MUI/Radix APIs
- [ ] Confirm `MANIFEST_SPEC_VERSION` export is `'1.0'` in built output

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)