### PR TITLE
feat(atoms): Slider component

### DIFF
--- a/dev/ComponentPreview.tsx
+++ b/dev/ComponentPreview.tsx
@@ -25,6 +25,7 @@ import { Breadcrumb } from '../src/components/molecules/Breadcrumb/index.js';
 import { Tabs } from '../src/components/molecules/Tabs/index.js';
 import { Collapsible } from '../src/components/molecules/Collapsible/index.js';
 import { NavLink } from '../src/components/atoms/NavLink/index.js';
+import { Slider } from '../src/components/atoms/Slider/index.js';
 import { PageLayout } from '../src/components/molecules/PageLayout/index.js';
 import { DataTable } from '../src/components/molecules/DataTable/index.js';
 import { CommandPalette } from '../src/components/molecules/CommandPalette/index.js';
@@ -106,6 +107,7 @@ function Inner({
   const [radio, setRadio] = useState('option1');
   const [radioSize, setRadioSize] = useState('m');
   const [toggled, setToggled] = useState(false);
+  const [sliderValue, setSliderValue] = useState(40);
   const [selectVal, setSelectVal] = useState('');
   const [tags, setTags] = useState(['React', 'TypeScript', 'Design Systems']);
   const [searchQuery, setSearchQuery] = useState('');
@@ -416,6 +418,27 @@ function Inner({
         <Row label="Disabled" tokens={tokens}>
           <Toggle disabled label="Disabled off" />
           <Toggle disabled defaultChecked label="Disabled on" />
+        </Row>
+      </Section>
+
+      {/* Slider */}
+      <Section title="Slider" tokens={tokens}>
+        <Row label="Controlled" tokens={tokens}>
+          <div style={{ width: 280 }}>
+            <Slider label="Volume" showValue value={sliderValue} onChange={e => setSliderValue(Number(e.target.value))} />
+          </div>
+        </Row>
+        <Row label="Sizes" tokens={tokens}>
+          <div style={{ width: 280, display: 'flex', flexDirection: 'column', gap: 'var(--lucent-space-4)' }}>
+            <Slider size="sm" label="Small" showValue defaultValue={30} />
+            <Slider size="md" label="Medium" showValue defaultValue={50} />
+            <Slider size="lg" label="Large" showValue defaultValue={70} />
+          </div>
+        </Row>
+        <Row label="Disabled" tokens={tokens}>
+          <div style={{ width: 280 }}>
+            <Slider label="Locked" disabled defaultValue={40} showValue />
+          </div>
         </Row>
       </Section>
 

--- a/src/components/atoms/Slider/Slider.manifest.ts
+++ b/src/components/atoms/Slider/Slider.manifest.ts
@@ -1,0 +1,107 @@
+import type { ComponentManifest } from '../../../manifest/types.js';
+
+export const COMPONENT_MANIFEST: ComponentManifest = {
+  id: 'slider',
+  name: 'Slider',
+  tier: 'atom',
+  domain: 'neutral',
+  specVersion: '0.1',
+
+  description: 'A range input styled with Lucent tokens for selecting a numeric value within a bounded range.',
+
+  designIntent:
+    'Use Slider for continuous or stepped numeric inputs where the relative position matters — ' +
+    'volume, brightness, border radius, spacing scale. Pair with showValue when the exact ' +
+    'number is meaningful to the user. For precise numeric entry, use Input with type="number" ' +
+    'instead. Disabled state uses muted colours without opacity hacks.',
+
+  props: [
+    {
+      name: 'min',
+      type: 'number',
+      required: false,
+      default: '0',
+      description: 'Minimum value.',
+    },
+    {
+      name: 'max',
+      type: 'number',
+      required: false,
+      default: '100',
+      description: 'Maximum value.',
+    },
+    {
+      name: 'step',
+      type: 'number',
+      required: false,
+      default: '1',
+      description: 'Increment step between values.',
+    },
+    {
+      name: 'value',
+      type: 'number',
+      required: false,
+      description: 'Controlled current value. Pair with onChange.',
+    },
+    {
+      name: 'defaultValue',
+      type: 'number',
+      required: false,
+      description: 'Initial value for uncontrolled usage. Defaults to the midpoint of min/max.',
+    },
+    {
+      name: 'onChange',
+      type: 'function',
+      required: false,
+      description: 'Called on every value change.',
+    },
+    {
+      name: 'label',
+      type: 'string',
+      required: false,
+      description: 'Visible label rendered above the track.',
+    },
+    {
+      name: 'showValue',
+      type: 'boolean',
+      required: false,
+      default: 'false',
+      description: 'Displays the current numeric value to the right of the label.',
+    },
+    {
+      name: 'size',
+      type: 'enum',
+      required: false,
+      default: 'md',
+      description: 'Controls track thickness and thumb diameter.',
+      enumValues: ['sm', 'md', 'lg'],
+    },
+    {
+      name: 'disabled',
+      type: 'boolean',
+      required: false,
+      default: 'false',
+      description: 'Prevents interaction and dims the control.',
+    },
+  ],
+
+  usageExamples: [
+    { title: 'Basic', code: `<Slider label="Volume" showValue />` },
+    { title: 'Controlled', code: `<Slider label="Opacity" min={0} max={1} step={0.01} value={opacity} onChange={e => setOpacity(Number(e.target.value))} showValue />` },
+    { title: 'Sizes', code: `<Slider size="sm" label="Small" />\n<Slider size="md" label="Medium" />\n<Slider size="lg" label="Large" />` },
+    { title: 'Disabled', code: `<Slider label="Locked" disabled defaultValue={40} />` },
+  ],
+
+  compositionGraph: [],
+
+  accessibility: {
+    role: 'slider',
+    ariaAttributes: ['aria-valuemin', 'aria-valuemax', 'aria-valuenow', 'aria-disabled'],
+    keyboardInteractions: [
+      'ArrowRight / ArrowUp — increase value by step',
+      'ArrowLeft / ArrowDown — decrease value by step',
+      'Home — jump to min',
+      'End — jump to max',
+    ],
+  },
+};

--- a/src/components/atoms/Slider/Slider.tsx
+++ b/src/components/atoms/Slider/Slider.tsx
@@ -1,0 +1,210 @@
+import { useState, type InputHTMLAttributes } from 'react';
+
+export type SliderSize = 'sm' | 'md' | 'lg';
+
+export interface SliderProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'size' | 'type'> {
+  label?: string;
+  showValue?: boolean;
+  size?: SliderSize;
+  min?: number;
+  max?: number;
+  step?: number;
+  value?: number;
+  defaultValue?: number;
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+const TRACK_H: Record<SliderSize, string> = { sm: '3px', md: '4px', lg: '5px' };
+const THUMB_S: Record<SliderSize, string> = { sm: '14px', md: '18px', lg: '22px' };
+
+const STYLES = `
+.lucent-slider {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 100%;
+  background: transparent;
+  cursor: pointer;
+  outline: none;
+  margin: 0;
+  padding: 6px 0;
+  box-sizing: border-box;
+}
+.lucent-slider:disabled { cursor: not-allowed; }
+
+/* WebKit track */
+.lucent-slider::-webkit-slider-runnable-track {
+  height: var(--ls-track-h);
+  border-radius: 999px;
+  background: linear-gradient(
+    to right,
+    var(--lucent-accent-default) 0%,
+    var(--lucent-accent-default) var(--ls-fill),
+    var(--lucent-border-default) var(--ls-fill),
+    var(--lucent-border-default) 100%
+  );
+}
+.lucent-slider:disabled::-webkit-slider-runnable-track {
+  background: var(--lucent-border-default);
+}
+
+/* WebKit thumb */
+.lucent-slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: var(--ls-thumb);
+  height: var(--ls-thumb);
+  border-radius: 50%;
+  background: var(--lucent-accent-default);
+  border: 2px solid var(--lucent-surface-default);
+  box-shadow: 0 1px 3px rgb(0 0 0 / 0.15);
+  margin-top: calc((var(--ls-thumb) - var(--ls-track-h)) / -2);
+  transition: transform 120ms ease, box-shadow 120ms ease;
+  cursor: pointer;
+}
+.lucent-slider:not(:disabled):hover::-webkit-slider-thumb {
+  transform: scale(1.15);
+}
+.lucent-slider:focus-visible::-webkit-slider-thumb {
+  box-shadow: 0 0 0 3px var(--lucent-accent-subtle);
+}
+.lucent-slider:disabled::-webkit-slider-thumb {
+  background: var(--lucent-bg-muted);
+  border-color: var(--lucent-border-default);
+  cursor: not-allowed;
+}
+
+/* Firefox track */
+.lucent-slider::-moz-range-track {
+  height: var(--ls-track-h);
+  border-radius: 999px;
+  background: var(--lucent-border-default);
+}
+.lucent-slider::-moz-range-progress {
+  height: var(--ls-track-h);
+  border-radius: 999px;
+  background: var(--lucent-accent-default);
+}
+.lucent-slider:disabled::-moz-range-progress {
+  background: transparent;
+}
+
+/* Firefox thumb */
+.lucent-slider::-moz-range-thumb {
+  width: var(--ls-thumb);
+  height: var(--ls-thumb);
+  border-radius: 50%;
+  background: var(--lucent-accent-default);
+  border: 2px solid var(--lucent-surface-default);
+  box-shadow: 0 1px 3px rgb(0 0 0 / 0.15);
+  cursor: pointer;
+  transition: transform 120ms ease, box-shadow 120ms ease;
+}
+.lucent-slider:not(:disabled):hover::-moz-range-thumb {
+  transform: scale(1.15);
+}
+.lucent-slider:focus-visible::-moz-range-thumb {
+  box-shadow: 0 0 0 3px var(--lucent-accent-subtle);
+}
+.lucent-slider:disabled::-moz-range-thumb {
+  background: var(--lucent-bg-muted);
+  border-color: var(--lucent-border-default);
+  cursor: not-allowed;
+}
+`;
+
+export function Slider({
+  label,
+  showValue = false,
+  size = 'md',
+  min = 0,
+  max = 100,
+  step = 1,
+  value,
+  defaultValue,
+  disabled,
+  id,
+  onChange,
+  style,
+  ...rest
+}: SliderProps) {
+  const inputId = id ?? `lucent-slider-${Math.random().toString(36).slice(2, 7)}`;
+  const isControlled = value !== undefined;
+  const [internalValue, setInternalValue] = useState<number>(
+    defaultValue ?? Math.round((min + max) / 2),
+  );
+  const currentValue = isControlled ? value : internalValue;
+  const fillPct = `${((currentValue - min) / (max - min)) * 100}%`;
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (!isControlled) setInternalValue(Number(e.target.value));
+    onChange?.(e);
+  };
+
+  return (
+    <>
+      <style>{STYLES}</style>
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 'var(--lucent-space-1)',
+          width: '100%',
+          fontFamily: 'var(--lucent-font-family-base)',
+          ...style,
+        }}
+      >
+        {(label || showValue) && (
+          <div
+            style={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'baseline',
+            }}
+          >
+            {label && (
+              <label
+                htmlFor={inputId}
+                style={{
+                  fontSize: 'var(--lucent-font-size-sm)',
+                  fontWeight: 'var(--lucent-font-weight-medium)',
+                  color: disabled ? 'var(--lucent-text-disabled)' : 'var(--lucent-text-primary)',
+                  cursor: disabled ? 'not-allowed' : 'default',
+                }}
+              >
+                {label}
+              </label>
+            )}
+            {showValue && (
+              <span
+                style={{
+                  fontSize: 'var(--lucent-font-size-sm)',
+                  color: disabled ? 'var(--lucent-text-disabled)' : 'var(--lucent-text-secondary)',
+                  fontVariantNumeric: 'tabular-nums',
+                }}
+              >
+                {currentValue}
+              </span>
+            )}
+          </div>
+        )}
+        <input
+          type="range"
+          id={inputId}
+          className="lucent-slider"
+          min={min}
+          max={max}
+          step={step}
+          disabled={disabled}
+          value={isControlled ? value : internalValue}
+          onChange={handleChange}
+          style={{
+            ['--ls-track-h' as string]: TRACK_H[size],
+            ['--ls-thumb' as string]: THUMB_S[size],
+            ['--ls-fill' as string]: fillPct,
+          }}
+          {...rest}
+        />
+      </div>
+    </>
+  );
+}

--- a/src/components/atoms/Slider/index.ts
+++ b/src/components/atoms/Slider/index.ts
@@ -1,0 +1,3 @@
+export { Slider } from './Slider.js';
+export type { SliderProps, SliderSize } from './Slider.js';
+export { COMPONENT_MANIFEST as SliderManifest } from './Slider.manifest.js';

--- a/src/components/atoms/index.ts
+++ b/src/components/atoms/index.ts
@@ -14,3 +14,4 @@ export * from './Tooltip/index.js';
 export * from './Icon/index.js';
 export * from './Text/index.js';
 export * from './NavLink/index.js';
+export * from './Slider/index.js';


### PR DESCRIPTION
## Summary

- Adds `Slider` atom wrapping `<input type="range">` styled entirely with Lucent tokens
- Accent-colored filled track via CSS linear-gradient driven by a `--ls-fill` CSS variable computed from the current value
- Thumb hover scale (1.15×) and focus ring (`accent-subtle`) via injected `<style>` pseudo-element rules
- `size` prop (`sm` / `md` / `lg`) controls track thickness and thumb diameter
- `label`, `showValue`, `disabled`, controlled/uncontrolled — all supported
- Manifest (`Slider.manifest.ts`) with full prop docs, usage examples, and accessibility notes
- ComponentPreview section: Controlled, Sizes, Disabled rows

## Test plan

- [ ] Drag slider — filled track updates in real time
- [ ] Controlled row value readout matches drag position
- [ ] Sizes row: three distinct track/thumb sizes visible
- [ ] Disabled row: muted colours, no interaction
- [ ] Keyboard: Arrow keys, Home, End move value
- [ ] Focus ring appears on focus-visible
- [ ] Light and dark themes both look correct

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)