### PR TITLE
feat(atoms): Table primitive component

### DIFF
--- a/dev/ComponentPreview.tsx
+++ b/dev/ComponentPreview.tsx
@@ -27,6 +27,7 @@ import { Collapsible } from '../src/components/molecules/Collapsible/index.js';
 import { NavLink } from '../src/components/atoms/NavLink/index.js';
 import { Slider } from '../src/components/atoms/Slider/index.js';
 import { CodeBlock } from '../src/components/atoms/CodeBlock/index.js';
+import { Table } from '../src/components/atoms/Table/index.js';
 import { PageLayout } from '../src/components/molecules/PageLayout/index.js';
 import { DataTable } from '../src/components/molecules/DataTable/index.js';
 import { CommandPalette } from '../src/components/molecules/CommandPalette/index.js';
@@ -494,6 +495,64 @@ function Inner({
           <div style={{ width: '100%' }}>
             <CodeBlock showCopyButton={false} language="bash" code="npm install lucent-ui" />
           </div>
+        </Row>
+      </Section>
+
+      {/* Table */}
+      <Section title="Table" tokens={tokens}>
+        <Row label="Basic" tokens={tokens}>
+          <Table>
+            <Table.Head>
+              <Table.Row>
+                <Table.Cell as="th">Prop</Table.Cell>
+                <Table.Cell as="th">Type</Table.Cell>
+                <Table.Cell as="th">Default</Table.Cell>
+                <Table.Cell as="th">Description</Table.Cell>
+              </Table.Row>
+            </Table.Head>
+            <Table.Body>
+              {[
+                ['variant', '"primary" | "secondary" | "ghost" | "danger"', '"primary"', 'Visual style of the button'],
+                ['size', '"sm" | "md" | "lg"', '"md"', 'Controls height and padding'],
+                ['disabled', 'boolean', 'false', 'Prevents interaction'],
+                ['loading', 'boolean', 'false', 'Shows a spinner, disables click'],
+              ].map(([prop, type, def, desc]) => (
+                <Table.Row key={prop}>
+                  <Table.Cell style={{ fontFamily: 'var(--lucent-font-family-mono)', fontSize: 'var(--lucent-font-size-xs)' }}>{prop}</Table.Cell>
+                  <Table.Cell style={{ fontFamily: 'var(--lucent-font-family-mono)', fontSize: 'var(--lucent-font-size-xs)', color: 'var(--lucent-text-secondary)' }}>{type}</Table.Cell>
+                  <Table.Cell style={{ fontFamily: 'var(--lucent-font-family-mono)', fontSize: 'var(--lucent-font-size-xs)' }}>{def}</Table.Cell>
+                  <Table.Cell>{desc}</Table.Cell>
+                </Table.Row>
+              ))}
+            </Table.Body>
+          </Table>
+        </Row>
+        <Row label="Striped" tokens={tokens}>
+          <Table striped>
+            <Table.Head>
+              <Table.Row>
+                <Table.Cell as="th">Name</Table.Cell>
+                <Table.Cell as="th">Role</Table.Cell>
+                <Table.Cell as="th">Status</Table.Cell>
+              </Table.Row>
+            </Table.Head>
+            <Table.Body>
+              {[
+                ['Alice', 'Engineer', 'Active'],
+                ['Bob', 'Designer', 'Away'],
+                ['Carol', 'Product', 'Active'],
+                ['Dan', 'Engineer', 'Active'],
+              ].map(([name, role, status]) => (
+                <Table.Row key={name}>
+                  <Table.Cell>{name}</Table.Cell>
+                  <Table.Cell>{role}</Table.Cell>
+                  <Table.Cell>
+                    <Badge variant={status === 'Active' ? 'success' : 'neutral'}>{status}</Badge>
+                  </Table.Cell>
+                </Table.Row>
+              ))}
+            </Table.Body>
+          </Table>
         </Row>
       </Section>
 

--- a/src/components/atoms/Table/Table.manifest.ts
+++ b/src/components/atoms/Table/Table.manifest.ts
@@ -1,0 +1,109 @@
+import type { ComponentManifest } from '../../../manifest/types.js';
+
+export const COMPONENT_MANIFEST: ComponentManifest = {
+  id: 'table',
+  name: 'Table',
+  tier: 'atom',
+  domain: 'neutral',
+  specVersion: '0.1',
+
+  description:
+    'A lightweight, token-styled HTML table primitive with compound sub-components. ' +
+    'Distinct from DataTable — no sorting, filtering, or pagination.',
+
+  designIntent:
+    'Use Table for static or lightly dynamic tabular data where full DataTable features ' +
+    'are not needed — props tables, changelog entries, comparison grids, reference docs. ' +
+    'The compound API (Table.Head, Table.Body, Table.Row, Table.Cell) maps directly to ' +
+    'semantic HTML so screen readers get the full table structure. ' +
+    'Horizontal overflow is handled automatically by a scroll wrapper.',
+
+  props: [
+    {
+      name: 'striped',
+      type: 'boolean',
+      required: false,
+      default: 'false',
+      description: 'Applies alternating bgMuted backgrounds to even tbody rows.',
+    },
+    {
+      name: 'Table.Head',
+      type: 'component',
+      required: false,
+      description: 'Renders <thead> with bgMuted background. Accepts Table.Row children.',
+    },
+    {
+      name: 'Table.Body',
+      type: 'component',
+      required: false,
+      description: 'Renders <tbody>. Accepts Table.Row children.',
+    },
+    {
+      name: 'Table.Foot',
+      type: 'component',
+      required: false,
+      description: 'Renders <tfoot> with bgMuted background.',
+    },
+    {
+      name: 'Table.Row',
+      type: 'component',
+      required: false,
+      description: 'Renders <tr> with a hover highlight. Accepts Table.Cell children.',
+    },
+    {
+      name: 'Table.Cell',
+      type: 'component',
+      required: false,
+      description:
+        'Renders <td> by default or <th scope="col"> when as="th". ' +
+        'Header cells are semibold + secondary colour; data cells are regular + primary.',
+    },
+  ],
+
+  usageExamples: [
+    {
+      title: 'Basic',
+      code: `<Table>
+  <Table.Head>
+    <Table.Row>
+      <Table.Cell as="th">Name</Table.Cell>
+      <Table.Cell as="th">Role</Table.Cell>
+    </Table.Row>
+  </Table.Head>
+  <Table.Body>
+    <Table.Row>
+      <Table.Cell>Alice</Table.Cell>
+      <Table.Cell>Engineer</Table.Cell>
+    </Table.Row>
+  </Table.Body>
+</Table>`,
+    },
+    {
+      title: 'Striped',
+      code: `<Table striped>
+  <Table.Head>…</Table.Head>
+  <Table.Body>…</Table.Body>
+</Table>`,
+    },
+    {
+      title: 'Custom cell content',
+      code: `<Table.Cell>
+  <Badge variant="success">Active</Badge>
+</Table.Cell>`,
+    },
+  ],
+
+  compositionGraph: [
+    { componentId: 'table-head', componentName: 'Table.Head', role: 'head', required: false },
+    { componentId: 'table-body', componentName: 'Table.Body', role: 'body', required: false },
+    { componentId: 'table-foot', componentName: 'Table.Foot', role: 'foot', required: false },
+    { componentId: 'table-row',  componentName: 'Table.Row',  role: 'row',  required: false },
+    { componentId: 'table-cell', componentName: 'Table.Cell', role: 'cell', required: false },
+  ],
+
+  accessibility: {
+    role: 'table',
+    ariaAttributes: ['scope="col" on th cells'],
+    keyboardInteractions: ['Standard browser table navigation'],
+  },
+};

--- a/src/components/atoms/Table/Table.tsx
+++ b/src/components/atoms/Table/Table.tsx
@@ -1,0 +1,135 @@
+import { type HTMLAttributes, type TdHTMLAttributes, type ThHTMLAttributes } from 'react';
+
+export interface TableProps extends HTMLAttributes<HTMLTableElement> {
+  /** Applies alternating row backgrounds to tbody rows */
+  striped?: boolean;
+}
+
+export type TableCellProps =
+  | ({ as?: 'td' } & TdHTMLAttributes<HTMLTableCellElement>)
+  | ({ as: 'th' } & ThHTMLAttributes<HTMLTableCellElement>);
+
+const STYLES = `
+.lucent-table-row:hover > td,
+.lucent-table-row:hover > th {
+  background: var(--lucent-bg-hover) !important;
+}
+.lucent-table-striped tbody .lucent-table-row:nth-child(even) > td,
+.lucent-table-striped tbody .lucent-table-row:nth-child(even) > th {
+  background: var(--lucent-bg-muted);
+}
+`;
+
+function Head({ children, style, ...rest }: HTMLAttributes<HTMLTableSectionElement>) {
+  return (
+    <thead
+      style={{
+        background: 'var(--lucent-bg-muted)',
+        ...style,
+      }}
+      {...rest}
+    >
+      {children}
+    </thead>
+  );
+}
+
+function Body({ children, ...rest }: HTMLAttributes<HTMLTableSectionElement>) {
+  return <tbody {...rest}>{children}</tbody>;
+}
+
+function Foot({ children, style, ...rest }: HTMLAttributes<HTMLTableSectionElement>) {
+  return (
+    <tfoot
+      style={{
+        background: 'var(--lucent-bg-muted)',
+        ...style,
+      }}
+      {...rest}
+    >
+      {children}
+    </tfoot>
+  );
+}
+
+function Row({ children, className, ...rest }: HTMLAttributes<HTMLTableRowElement>) {
+  return (
+    <tr
+      className={['lucent-table-row', className].filter(Boolean).join(' ')}
+      {...rest}
+    >
+      {children}
+    </tr>
+  );
+}
+
+function Cell({ as, children, style, ...rest }: TableCellProps) {
+  const isHeader = as === 'th';
+  const Tag = isHeader ? 'th' : 'td';
+
+  const cellStyle: React.CSSProperties = {
+    padding: 'var(--lucent-space-3) var(--lucent-space-4)',
+    fontFamily: 'var(--lucent-font-family-base)',
+    fontSize: 'var(--lucent-font-size-sm)',
+    borderBottom: '1px solid var(--lucent-border-default)',
+    textAlign: 'left',
+    verticalAlign: 'middle',
+    color: isHeader ? 'var(--lucent-text-secondary)' : 'var(--lucent-text-primary)',
+    fontWeight: isHeader
+      ? 'var(--lucent-font-weight-semibold)'
+      : 'var(--lucent-font-weight-regular)',
+    whiteSpace: isHeader ? 'nowrap' : undefined,
+    ...style,
+  };
+
+  if (isHeader) {
+    return (
+      <th scope="col" style={cellStyle} {...(rest as ThHTMLAttributes<HTMLTableCellElement>)}>
+        {children}
+      </th>
+    );
+  }
+
+  return (
+    <td style={cellStyle} {...(rest as TdHTMLAttributes<HTMLTableCellElement>)}>
+      {children}
+    </td>
+  );
+}
+
+function Table({ striped = false, children, className, style, ...rest }: TableProps) {
+  const classes = [
+    'lucent-table',
+    striped && 'lucent-table-striped',
+    className,
+  ].filter(Boolean).join(' ');
+
+  return (
+    <>
+      <style>{STYLES}</style>
+      <div style={{ overflowX: 'auto', width: '100%' }}>
+        <table
+          className={classes}
+          style={{
+            width: '100%',
+            borderCollapse: 'collapse',
+            fontFamily: 'var(--lucent-font-family-base)',
+            fontSize: 'var(--lucent-font-size-sm)',
+            ...style,
+          }}
+          {...rest}
+        >
+          {children}
+        </table>
+      </div>
+    </>
+  );
+}
+
+Table.Head = Head;
+Table.Body = Body;
+Table.Foot = Foot;
+Table.Row = Row;
+Table.Cell = Cell;
+
+export { Table };

--- a/src/components/atoms/Table/index.ts
+++ b/src/components/atoms/Table/index.ts
@@ -1,0 +1,3 @@
+export { Table } from './Table.js';
+export type { TableProps, TableCellProps } from './Table.js';
+export { COMPONENT_MANIFEST as TableManifest } from './Table.manifest.js';

--- a/src/components/atoms/index.ts
+++ b/src/components/atoms/index.ts
@@ -16,3 +16,4 @@ export * from './Text/index.js';
 export * from './NavLink/index.js';
 export * from './Slider/index.js';
 export * from './CodeBlock/index.js';
+export * from './Table/index.js';


### PR DESCRIPTION
## Summary

- Compound component API: `Table` + `Table.Head` / `Table.Body` / `Table.Foot` / `Table.Row` / `Table.Cell`
- `Table.Cell` renders `<td>` by default; `as="th"` renders `<th scope="col">` — header cells are semibold + secondary colour
- Row hover highlight via injected CSS class (`.lucent-table-row:hover > td/th`) — no React state needed
- `striped` prop applies CSS `nth-child(even)` on tbody rows using a `.lucent-table-striped` class
- Horizontal overflow scroll wrapper built into `Table` root for responsive layouts
- No sorting, filtering, or pagination — pure presentational primitive
- Manifest with compound sub-component docs + usage examples
- ComponentPreview: props table row (basic) + striped table with Badge status cells

## Test plan

- [ ] Basic table renders correct `<thead>` / `<tbody>` / `<th>` / `<td>` structure
- [ ] `th` cells: semibold, secondary colour; `td` cells: regular, primary colour
- [ ] Row hover shows bgHover across all cells
- [ ] `striped` — even rows have bgMuted background, hover still overrides
- [ ] Horizontal scroll works on a narrow container
- [ ] Custom cell content (Badge) renders correctly
- [ ] Light and dark themes both look correct

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)