### PR TITLE
feat(customizer): add border color picker with theme-aware derivation

### DIFF
--- a/dev/ComponentPreview.tsx
+++ b/dev/ComponentPreview.tsx
@@ -1,5 +1,6 @@
-import { useState } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { LucentProvider, useLucent, brandTokens } from '../src/index.js';
+import { adjustLightness, getThemeComplementBorderColor, deriveBorderVariants } from '../src/tokens/color.js';
 import { Button } from '../src/components/atoms/Button/index.js';
 import { Input } from '../src/components/atoms/Input/index.js';
 import { Textarea } from '../src/components/atoms/Textarea/index.js';
@@ -73,19 +74,34 @@ function StarIcon() {
 export function ComponentPreview() {
   const [theme, setTheme] = useState<Theme>('light');
   const [accent, setAccent] = useState<AccentPreset>('default');
+  const [overrides, setOverrides] = useState<Partial<LucentTokens>>({});
 
-  const tokenOverrides =
+  const tokenPreset =
     accent === 'gold' ? brandTokens :
     accent === 'indigo' ? indigoTokens :
     undefined;
 
+  const mergedTokens: Partial<LucentTokens> = {
+    ...(tokenPreset || {}),
+    ...overrides,
+  };
+
+  const handleTokenChange = (key: keyof LucentTokens, value: string) => {
+    setOverrides(prev => ({ ...prev, [key]: value }));
+  };
+
+  const clearOverrides = () => setOverrides({});
+
   return (
-    <LucentProvider theme={theme} tokens={tokenOverrides}>
+    <LucentProvider theme={theme} tokens={mergedTokens}>
       <Inner
         theme={theme}
         accent={accent}
+        overrides={overrides}
         onToggleTheme={() => setTheme(t => t === 'light' ? 'dark' : 'light')}
         onSetAccent={setAccent}
+        onChangeOverride={handleTokenChange}
+        clearOverrides={clearOverrides}
       />
     </LucentProvider>
   );
@@ -94,17 +110,25 @@ export function ComponentPreview() {
 function Inner({
   theme,
   accent,
+  overrides,
   onToggleTheme,
   onSetAccent,
+  onChangeOverride,
+  clearOverrides,
 }: {
   theme: Theme;
   accent: AccentPreset;
+  overrides: Partial<LucentTokens>;
   onToggleTheme: () => void;
   onSetAccent: (p: AccentPreset) => void;
+  onChangeOverride: (key: keyof LucentTokens, value: string) => void;
+  clearOverrides: () => void;
 }) {
   const { tokens } = useLucent();
   const [inputVal, setInputVal] = useState('');
   const [textareaVal, setTextareaVal] = useState('');
+  const [deriveAccent, setDeriveAccent] = useState(true);
+  const [deriveBorder, setDeriveBorder] = useState(true);
   const [checked, setChecked] = useState(false);
   const [radio, setRadio] = useState('option1');
   const [radioSize, setRadioSize] = useState('m');
@@ -115,6 +139,126 @@ function Inner({
   const [searchQuery, setSearchQuery] = useState('');
   const [alertDismissed, setAlertDismissed] = useState(false);
 
+  // font scale slider (percentage of base)
+  const [fontScalePercent, setFontScalePercent] = useState(100);
+  const baseFontSizesRef = useRef<Record<string, string>>({});
+
+  // spacing scale slider
+  const [spaceScalePercent, setSpaceScalePercent] = useState(100);
+  const baseSpaceRef = useRef<Record<string, string>>({});
+
+  const [radiusPx, setRadiusPx] = useState(() => {
+    const raw = tokens.radiusLg;
+    if (raw.endsWith('px')) return parseInt(raw);
+    if (raw.endsWith('rem')) return Math.round(parseFloat(raw) * 16);
+    return 0;
+  });
+
+  // track border colors per theme for context-aware derivation
+  const borderColorsRef = useRef<{ light: string; dark: string }>({ light: '', dark: '' });
+
+  // when deriveAccent toggled on or base color/theme changes, update other tokens
+  useEffect(() => {
+    if (deriveAccent) {
+      const base = tokens.accentDefault;
+      const hover = theme === 'light' ? adjustLightness(base, -0.08) : adjustLightness(base, 0.08);
+      const active = theme === 'light' ? adjustLightness(base, -0.12) : adjustLightness(base, 0.12);
+      const subtle = theme === 'light' ? adjustLightness(base, 0.8) : adjustLightness(base, -0.8);
+      const border = theme === 'light' ? adjustLightness(base, -0.15) : adjustLightness(base, 0.15);
+      onChangeOverride('accentHover', hover);
+      onChangeOverride('accentActive', active);
+      onChangeOverride('accentSubtle', subtle);
+      onChangeOverride('accentBorder', border);
+    }
+  }, [deriveAccent, theme, tokens.accentDefault]);
+
+  // when deriveBorder toggled on or base color/theme changes, update other tokens
+  useEffect(() => {
+    if (deriveBorder) {
+      const base = tokens.borderDefault;
+      const variants = deriveBorderVariants(base);
+      onChangeOverride('borderSubtle', variants.subtle);
+      onChangeOverride('borderStrong', variants.strong);
+    }
+  }, [deriveBorder, tokens.borderDefault]);
+
+  // when theme changes, switch to the complementary border color for that theme
+  useEffect(() => {
+    if (deriveBorder) {
+      const colorKey = theme === 'light' ? 'light' : 'dark';
+      const otherKey = theme === 'light' ? 'dark' : 'light';
+
+      // if we have a color stored for the current theme, use it
+      if (borderColorsRef.current[colorKey]) {
+        onChangeOverride('borderDefault', borderColorsRef.current[colorKey]);
+      } else {
+        // first time in this theme, compute complement of the other theme's color
+        const currentColor = tokens.borderDefault;
+        const complement = getThemeComplementBorderColor(currentColor);
+        borderColorsRef.current[colorKey] = complement;
+        onChangeOverride('borderDefault', complement);
+      }
+    }
+  }, [theme, deriveBorder]);
+
+  // keep slider in sync if token changes externally
+  useEffect(() => {
+    const raw = tokens.radiusLg;
+    const px = raw.endsWith('px') ? parseInt(raw) : raw.endsWith('rem') ? Math.round(parseFloat(raw) * 16) : 0;
+    setRadiusPx(px);
+  }, [tokens.radiusLg, tokens.radiusMd, tokens.radiusSm, tokens.radiusXl, tokens.radiusFull]);
+
+  // remember original font sizes once, then keep scale state updated
+  useEffect(() => {
+    if (Object.keys(baseFontSizesRef.current).length === 0) {
+      [
+        'fontSizeXs','fontSizeSm','fontSizeMd','fontSizeLg','fontSizeXl','fontSize2xl','fontSize3xl'
+      ].forEach(k => {
+        baseFontSizesRef.current[k] = tokens[k as keyof typeof tokens] as string;
+      });
+    }
+
+    if (Object.keys(baseSpaceRef.current).length === 0) {
+      Object.keys(tokens)
+        .filter(k => k.startsWith('space'))
+        .forEach(k => {
+          baseSpaceRef.current[k] = tokens[k as keyof typeof tokens] as string;
+        });
+    }
+  }, [tokens]);
+
+  useEffect(() => {
+    // if any font token changes outside the slider, recompute percent
+    const raw = tokens.fontSizeMd;
+    const baseRaw = baseFontSizesRef.current.fontSizeMd;
+    if (baseRaw) {
+      const num = parseFloat(raw);
+      const baseNum = parseFloat(baseRaw);
+      const percent = Math.round((num / baseNum) * 100);
+      setFontScalePercent(percent);
+    }
+  }, [
+    tokens.fontSizeXs,
+    tokens.fontSizeSm,
+    tokens.fontSizeMd,
+    tokens.fontSizeLg,
+    tokens.fontSizeXl,
+    tokens.fontSize2xl,
+    tokens.fontSize3xl,
+  ]);
+
+  useEffect(() => {
+    // keep spacing slider in sync when spacing tokens change externally
+    const raw = tokens.space4; // use mid-level token as reference
+    const baseRaw = baseSpaceRef.current.space4;
+    if (baseRaw) {
+      const num = parseFloat(raw);
+      const baseNum = parseFloat(baseRaw);
+      const percent = Math.round((num / baseNum) * 100);
+      setSpaceScalePercent(percent);
+    }
+  }, [tokens]);
+
   const allFruits = ['Apple', 'Apricot', 'Banana', 'Blueberry', 'Cherry', 'Grape', 'Mango', 'Orange', 'Peach', 'Pear', 'Pineapple', 'Strawberry'];
   const searchResults = searchQuery.length > 0
     ? allFruits
@@ -123,36 +267,191 @@ function Inner({
     : [];
 
   return (
-    <div style={{ background: tokens.bgBase, color: tokens.textPrimary, fontFamily: tokens.fontFamilyBase, minHeight: '100vh', padding: tokens.space8 }}>
+    <div style={{ background: tokens.bgBase, color: tokens.textPrimary, fontFamily: tokens.fontFamilyBase, minHeight: '100vh', padding: tokens.space8, paddingRight: '280px' }}>
       {/* Header */}
+      {/* Customizer sidebar */}
+      <div style={{
+        position: 'fixed',
+        right: 0,
+        top: 0,
+        bottom: 0,
+        width: 240,
+        overflowY: 'auto',
+        padding: tokens.space4,
+        background: tokens.surfaceDefault,
+        borderLeft: `1px solid ${tokens.borderDefault}`,
+        zIndex: 1000,
+      }}>
+        <h2 style={{ fontSize: tokens.fontSizeLg, fontWeight: tokens.fontWeightSemibold, marginTop: 0 }}>Customizer</h2>
+        <div style={{ marginBottom: tokens.space6 }}>
+          <Toggle label="Dark mode" checked={theme === 'dark'} onChange={onToggleTheme} />
+          <div style={{ marginTop: tokens.space4, display: 'flex', flexDirection: 'column', gap: tokens.space2 }}>
+            {(['default', 'gold', 'indigo'] as AccentPreset[]).map(p => (
+              <button
+                key={p}
+                onClick={() => onSetAccent(p)}
+                style={{
+                  padding: `${tokens.space1} ${tokens.space3}`,
+                  border: `1px solid ${accent === p ? tokens.accentDefault : tokens.borderDefault}`,
+                  borderRadius: tokens.radiusMd,
+                  background: accent === p ? tokens.accentDefault : tokens.surfaceDefault,
+                  color: accent === p ? tokens.textOnAccent : tokens.textPrimary,
+                  fontFamily: tokens.fontFamilyBase,
+                  fontSize: tokens.fontSizeSm,
+                  fontWeight: accent === p ? tokens.fontWeightSemibold : tokens.fontWeightRegular,
+                  cursor: 'pointer',
+                }}
+              >
+                {accentLabel[p]}
+              </button>
+            ))}
+          </div>
+        </div>
+        <div style={{ marginBottom: tokens.space4 }}>
+          <label style={{ display: 'flex', alignItems: 'center', gap: tokens.space2 }}>
+            <input
+              type="checkbox"
+              checked={deriveAccent}
+              onChange={e => setDeriveAccent(e.target.checked)}
+            />
+            <span style={{ fontSize: tokens.fontSizeSm }}>Derive variants from accentDefault</span>
+          </label>
+        </div>
+        {(deriveAccent ? ['accentDefault'] : ['accentDefault', 'accentHover', 'accentActive', 'accentSubtle', 'accentBorder']).map(key => (
+          <div key={key} style={{ marginBottom: tokens.space4 }}>
+            <Input
+              type="color"
+              label={key}
+              value={tokens[key as keyof typeof tokens] as string}
+              onChange={e => {
+                const val = e.target.value;
+                onChangeOverride(key as keyof LucentTokens, val);
+                if (deriveAccent && key === 'accentDefault') {
+                  // compute derived tokens
+                  const base = val;
+                  const hover = theme === 'light' ? adjustLightness(base, -0.08) : adjustLightness(base, 0.08);
+                  const active = theme === 'light' ? adjustLightness(base, -0.12) : adjustLightness(base, 0.12);
+                  const subtle = theme === 'light' ? adjustLightness(base, 0.8) : adjustLightness(base, -0.8);
+                  const border = theme === 'light' ? adjustLightness(base, -0.15) : adjustLightness(base, 0.15);
+                  onChangeOverride('accentHover', hover);
+                  onChangeOverride('accentActive', active);
+                  onChangeOverride('accentSubtle', subtle);
+                  onChangeOverride('accentBorder', border);
+                }
+              }}
+            />
+          </div>
+        ))}
+
+        {/* border color pickers */}
+        <div style={{ marginTop: tokens.space6, marginBottom: tokens.space4, paddingTop: tokens.space4, borderTop: `1px solid ${tokens.borderDefault}` }}>
+          <span style={{ fontSize: tokens.fontSizeSm, fontWeight: tokens.fontWeightSemibold, display: 'block', marginBottom: tokens.space3 }}>Border Colors</span>
+        </div>
+        <div style={{ marginBottom: tokens.space4 }}>
+          <label style={{ display: 'flex', alignItems: 'center', gap: tokens.space2 }}>
+            <input
+              type="checkbox"
+              checked={deriveBorder}
+              onChange={e => setDeriveBorder(e.target.checked)}
+            />
+            <span style={{ fontSize: tokens.fontSizeSm }}>Derive variants from borderDefault</span>
+          </label>
+        </div>
+        {(deriveBorder ? ['borderDefault'] : ['borderDefault', 'borderSubtle', 'borderStrong']).map(key => (
+          <div key={key} style={{ marginBottom: tokens.space4 }}>
+            <Input
+              type="color"
+              label={key}
+              value={tokens[key as keyof typeof tokens] as string}
+              onChange={e => {
+                const val = e.target.value;
+                onChangeOverride(key as keyof LucentTokens, val);
+                if (deriveBorder && key === 'borderDefault') {
+                  // store this color for the current theme
+                  const colorKey = theme === 'light' ? 'light' : 'dark';
+                  borderColorsRef.current[colorKey] = val;
+
+                  // compute derived variants from the chosen color
+                  const variants = deriveBorderVariants(val);
+                  onChangeOverride('borderSubtle', variants.subtle);
+                  onChangeOverride('borderStrong', variants.strong);
+                }
+              }}
+            />
+          </div>
+        ))}
+
+        {/* font size scale slider */}
+        <div style={{ marginBottom: tokens.space4 }}>
+          <label style={{ display: 'flex', flexDirection: 'column', gap: tokens.space1 }}>
+            <span style={{ fontSize: tokens.fontSizeSm }}>Font scale ({fontScalePercent}%)</span>
+            <input
+              type="range"
+              min={50}
+              max={150}
+              value={fontScalePercent}
+              onChange={e => {
+                const pct = parseInt(e.target.value);
+                setFontScalePercent(pct);
+                const scale = pct / 100;
+                Object.entries(baseFontSizesRef.current).forEach(([key, val]) => {
+                  const num = parseFloat(val);
+                  const unit = val.replace(/[\d.]/g, '');
+                  onChangeOverride(key as keyof LucentTokens, `${num * scale}${unit}`);
+                });
+              }}
+            />
+          </label>
+        </div>
+
+        {/* spacing scale slider */}
+        <div style={{ marginBottom: tokens.space4 }}>
+          <label style={{ display: 'flex', flexDirection: 'column', gap: tokens.space1 }}>
+            <span style={{ fontSize: tokens.fontSizeSm }}>Spacing scale ({spaceScalePercent}%)</span>
+            <input
+              type="range"
+              min={50}
+              max={150}
+              value={spaceScalePercent}
+              onChange={e => {
+                const pct = parseInt(e.target.value);
+                setSpaceScalePercent(pct);
+                const scale = pct / 100;
+                Object.entries(baseSpaceRef.current).forEach(([key, val]) => {
+                  const num = parseFloat(val);
+                  const unit = val.replace(/[\d.]/g, '');
+                  onChangeOverride(key as keyof LucentTokens, `${num * scale}${unit}`);
+                });
+              }}
+            />
+          </label>
+        </div>
+
+        <div style={{ marginBottom: tokens.space4 }}>
+          <label style={{ display: 'flex', flexDirection: 'column', gap: tokens.space1 }}>
+            <span style={{ fontSize: tokens.fontSizeSm }}>Border radius ({radiusPx}px)</span>
+            <input
+              type="range"
+              min={0}
+              max={32}
+              value={radiusPx}
+              onChange={e => {
+                const v = parseInt(e.target.value);
+                setRadiusPx(v);
+                ['radiusSm','radiusMd','radiusLg','radiusXl','radiusFull'].forEach(k =>
+                  onChangeOverride(k as keyof LucentTokens, `${v}px`)
+                );
+              }}
+            />
+          </label>
+        </div>
+
+        <Button size="sm" onClick={clearOverrides}>Reset</Button>
+      </div>
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: tokens.space8, flexWrap: 'wrap', gap: tokens.space4 }}>
         <div>
           <h1 style={{ fontSize: tokens.fontSize2xl, fontWeight: tokens.fontWeightBold, margin: 0 }}>Lucent UI — Component Preview</h1>
           <p style={{ color: tokens.textSecondary, margin: `${tokens.space1} 0 0`, fontSize: tokens.fontSizeSm }}>Molecules Wave 1 · Atoms Wave 1 + 2 · {theme} mode · {accentLabel[accent]}</p>
-        </div>
-        <div style={{ display: 'flex', gap: tokens.space2, alignItems: 'center', flexWrap: 'wrap' }}>
-          {(['default', 'gold', 'indigo'] as AccentPreset[]).map(p => (
-            <button
-              key={p}
-              onClick={() => onSetAccent(p)}
-              style={{
-                padding: `${tokens.space1} ${tokens.space3}`,
-                border: `1px solid ${accent === p ? tokens.accentDefault : tokens.borderDefault}`,
-                borderRadius: tokens.radiusMd,
-                background: accent === p ? tokens.accentDefault : tokens.surfaceDefault,
-                color: accent === p ? tokens.textOnAccent : tokens.textPrimary,
-                fontFamily: tokens.fontFamilyBase,
-                fontSize: tokens.fontSizeSm,
-                fontWeight: accent === p ? tokens.fontWeightSemibold : tokens.fontWeightRegular,
-                cursor: 'pointer',
-              }}
-            >
-              {accentLabel[p]}
-            </button>
-          ))}
-          <Button variant="secondary" size="sm" onClick={onToggleTheme}>
-            {theme === 'light' ? 'Dark' : 'Light'} mode
-          </Button>
         </div>
       </div>
 
@@ -680,6 +979,7 @@ function Inner({
           <Button variant="secondary">Secondary</Button>
           <Button variant="ghost">Ghost</Button>
           <Button variant="danger">Danger</Button>
+          <Button variant="primary" bordered={false}>Flat</Button>
         </Row>
         <Row label="Sizes" tokens={tokens}>
           <Button size="sm">Small</Button>
@@ -713,7 +1013,7 @@ function Inner({
         </Row>
         <Row label="Error state" tokens={tokens}>
           <div style={{ width: 280 }}>
-            <Input label="Password" type="password" errorText="Must be at least 8 characters" value="short" />
+            <Input label="Password" type="password" errorText="Must be at least 8 characters" defaultValue="short" />
           </div>
         </Row>
       </Section>

--- a/docs/bring-your-own-tokens.md
+++ b/docs/bring-your-own-tokens.md
@@ -84,7 +84,15 @@ Only the tokens you include in the manifest are overridden — everything else f
 
 ### Theme-specific overrides
 
-You can supply only `light`, only `dark`, or both:
+You can supply only `light`, only `dark`, or both.  In many cases you
+only need to override the **accent** colour – Lucent will automatically
+compute a sensible border shade and ensure text on accent surfaces meets
+WCAG contrast in both light and dark mode.  This makes it hard to pick a
+combination that looks bad on one theme or the other.
+
+If you do want fine‑grained control you can still override the derived
+value (`accentBorder`) yourself; otherwise just set `accentDefault` and
+possibly hover/active/subtle variants.
 
 ```json
 {
@@ -97,11 +105,11 @@ You can supply only `light`, only `dark`, or both:
       "accentActive": "#5b21b6",
       "accentSubtle": "#f5f3ff",
       "focusRing": "#7c3aed"
+      // ``accentBorder`` is calculated automatically, no need to include it
     }
   }
 }
 ```
-
 ---
 
 ## Token reference

--- a/src/components/atoms/Button/Button.tsx
+++ b/src/components/atoms/Button/Button.tsx
@@ -16,13 +16,15 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   chevron?: boolean;
   /** Disables the built-in hover background/border overrides. Use when passing custom colours via style. */
   disableHoverStyles?: boolean;
+  /** If false, the component renders without any border. Useful when you want a solid "flat" look. */
+  bordered?: boolean;
 }
 
 const variantStyles: Record<ButtonVariant, CSSProperties> = {
   primary: {
     background: 'var(--lucent-accent-default)',
     color: 'var(--lucent-text-on-accent)',
-    border: '1px solid var(--lucent-accent-default)',
+    border: '1px solid var(--lucent-accent-border)',
   },
   secondary: {
     background: 'var(--lucent-surface-default)',
@@ -48,7 +50,7 @@ const sizeStyles: Record<ButtonSize, CSSProperties> = {
 };
 
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ variant = 'primary', size = 'md', loading = false, fullWidth = false, spread = false, leftIcon, rightIcon, chevron = false, disableHoverStyles = false, children, disabled, style, ...rest }, ref) => {
+  ({ variant = 'primary', size = 'md', loading = false, fullWidth = false, spread = false, leftIcon, rightIcon, chevron = false, disableHoverStyles = false, bordered = true, children, disabled, style, ...rest }, ref) => {
     const isDisabled = disabled ?? loading;
 
     return (
@@ -81,13 +83,15 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
             color: 'var(--lucent-text-disabled)',
             borderColor: 'transparent',
           }),
+          // hide border entirely when bordered prop is false
+          ...(bordered === false && { border: 'none' }),
         }}
         onMouseEnter={(e) => {
-          if (!isDisabled && !disableHoverStyles) applyHover(e.currentTarget, variant);
+          if (!isDisabled && !disableHoverStyles) applyHover(e.currentTarget, variant, bordered);
           rest.onMouseEnter?.(e);
         }}
         onMouseLeave={(e) => {
-          if (!isDisabled && !disableHoverStyles) removeHover(e.currentTarget, variant);
+          if (!isDisabled && !disableHoverStyles) removeHover(e.currentTarget, variant, bordered);
           rest.onMouseLeave?.(e);
         }}
         onMouseDown={(e) => {
@@ -119,31 +123,31 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
 
 Button.displayName = 'Button';
 
-function applyHover(el: HTMLButtonElement, variant: ButtonVariant) {
+function applyHover(el: HTMLButtonElement, variant: ButtonVariant, bordered?: boolean) {
   if (variant === 'primary') {
     el.style.background = 'var(--lucent-accent-hover)';
-    el.style.borderColor = 'var(--lucent-accent-hover)';
+    if (bordered !== false) el.style.borderColor = 'var(--lucent-accent-border)';
   } else if (variant === 'secondary') {
     el.style.background = 'var(--lucent-bg-subtle)';
   } else if (variant === 'ghost') {
     el.style.background = 'var(--lucent-bg-muted)';
   } else if (variant === 'danger') {
     el.style.background = 'var(--lucent-danger-hover)';
-    el.style.borderColor = 'var(--lucent-danger-hover)';
+    if (bordered !== false) el.style.borderColor = 'var(--lucent-danger-hover)';
   }
 }
 
-function removeHover(el: HTMLButtonElement, variant: ButtonVariant) {
+function removeHover(el: HTMLButtonElement, variant: ButtonVariant, bordered?: boolean) {
   if (variant === 'primary') {
     el.style.background = 'var(--lucent-accent-default)';
-    el.style.borderColor = 'var(--lucent-accent-default)';
+    if (bordered !== false) el.style.borderColor = 'var(--lucent-accent-border)';
   } else if (variant === 'secondary') {
     el.style.background = 'var(--lucent-surface-default)';
   } else if (variant === 'ghost') {
     el.style.background = 'transparent';
   } else if (variant === 'danger') {
     el.style.background = 'var(--lucent-danger-default)';
-    el.style.borderColor = 'var(--lucent-danger-default)';
+    if (bordered !== false) el.style.borderColor = 'var(--lucent-danger-default)';
   }
 }
 

--- a/src/components/atoms/Checkbox/Checkbox.tsx
+++ b/src/components/atoms/Checkbox/Checkbox.tsx
@@ -91,7 +91,11 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
     const boxStyle: CSSProperties = {
       width: px,
       height: px,
-      borderRadius: 'var(--lucent-radius-sm)',
+      // fixed corner so global radius overrides (e.g. via customizer) don't
+      // turn checkboxes into circles. the design spec keeps them slightly
+      // rounded regardless of theming.
+      // bumping up a bit to keep the box from feeling too sharp.
+      borderRadius: '4px',
       border: `1.5px solid ${disabled ? 'transparent' : isChecked || indeterminate ? 'var(--lucent-accent-default)' : 'var(--lucent-border-strong)'}`,
       background: disabled ? 'var(--lucent-bg-muted)' : isChecked || indeterminate ? 'var(--lucent-accent-default)' : 'var(--lucent-surface-default)',
       display: 'inline-flex',

--- a/src/components/atoms/Input/Input.tsx
+++ b/src/components/atoms/Input/Input.tsx
@@ -1,6 +1,14 @@
 import { forwardRef, type InputHTMLAttributes, type ReactNode } from 'react';
 
-export type InputType = 'text' | 'number' | 'password' | 'email' | 'tel' | 'url' | 'search';
+export type InputType =
+  | 'text'
+  | 'number'
+  | 'password'
+  | 'email'
+  | 'tel'
+  | 'url'
+  | 'search'
+  | 'color';
 
 export interface InputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'size'> {
   type?: InputType;

--- a/src/components/molecules/MultiSelect/MultiSelect.tsx
+++ b/src/components/molecules/MultiSelect/MultiSelect.tsx
@@ -3,6 +3,7 @@ import {
   type CSSProperties, type KeyboardEvent,
 } from 'react';
 import { Text } from '../../atoms/Text/index.js';
+import { Checkbox } from '../../atoms/Checkbox/index.js';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -263,25 +264,14 @@ export function MultiSelect({
                     opacity: isDisabled || wouldExceedMax ? 0.5 : 1,
                   }}
                 >
-                  {/* Checkbox indicator */}
-                  <span style={{
-                    flexShrink: 0,
-                    width: 16,
-                    height: 16,
-                    borderRadius: 'var(--lucent-radius-sm)',
-                    border: `1.5px solid ${isSelected ? 'var(--lucent-accent-default)' : 'var(--lucent-border-strong)'}`,
-                    background: isSelected ? 'var(--lucent-accent-default)' : 'transparent',
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    transition: 'background var(--lucent-duration-fast), border-color var(--lucent-duration-fast)',
-                  }}>
-                    {isSelected && (
-                      <svg width="10" height="10" viewBox="0 0 10 10" fill="none" aria-hidden>
-                        <path d="M2 5l2.5 2.5L8 3" stroke="var(--lucent-text-on-accent)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-                      </svg>
-                    )}
-                  </span>
+                  <Checkbox
+                    checked={isSelected}
+                    disabled={isDisabled || wouldExceedMax}
+                    size="md"
+                    style={{ margin: 0, pointerEvents: 'none' }}
+                    aria-hidden
+                    readOnly
+                  />
                   <Text size="sm">{opt.label}</Text>
                 </div>
               );

--- a/src/manifest/examples/button.manifest.ts
+++ b/src/manifest/examples/button.manifest.ts
@@ -59,6 +59,13 @@ export const ButtonManifest: ComponentManifest = {
       description: 'Stretches the button to fill its container width.',
     },
     {
+      name: 'bordered',
+      type: 'boolean',
+      required: false,
+      default: 'true',
+      description: 'When false removes the button border entirely, producing a flat look.',
+    },
+    {
       name: 'leftIcon',
       type: 'ReactNode',
       required: false,
@@ -109,6 +116,10 @@ export const ButtonManifest: ComponentManifest = {
     {
       title: 'Full-width submit',
       code: `<Button variant="primary" type="submit" fullWidth>Sign in</Button>`,
+    },
+    {
+      title: 'Borderless primary',
+      code: `<Button variant="primary" bordered={false}>Flat primary</Button>`,
     },
   ],
   compositionGraph: [],

--- a/src/provider/LucentProvider.tsx
+++ b/src/provider/LucentProvider.tsx
@@ -9,6 +9,7 @@ import { lightTokens } from '../tokens/light.js';
 import { darkTokens } from '../tokens/dark.js';
 import { makeLibraryCSS } from '../tokens/css.js';
 import { getContrastText } from '../tokens/contrast.js';
+import { adjustLightness } from '../tokens/color.js';
 import type { LucentTokens, Theme } from '../tokens/types.js';
 
 interface LucentContextValue {
@@ -47,12 +48,34 @@ export function LucentProvider({
   const merged: LucentTokens = tokenOverrides
     ? { ...baseTokens, ...tokenOverrides }
     : baseTokens;
+
   // Auto-compute textOnAccent from the resolved accent color unless the consumer
   // explicitly overrides it. This guarantees WCAG AA contrast on accent surfaces
   // regardless of which accent color is in use.
+  //
+  // We also derive a slightly tweaked border colour for the primary/accent
+  // variant so that when people supply a custom accent the border still has
+  // enough contrast against the surrounding surface in both light & dark
+  // themes.  The consumer can still override `accentBorder` if they really
+  // want to pick a specific value; this computation only applies when the
+  // token is _not_ provided.
+  const computedBorder = (() => {
+    // fast path: use provided override
+    if (tokenOverrides?.accentBorder) {
+      return tokenOverrides.accentBorder;
+    }
+    // light theme: darken the accent a little so the border isn't lost on a
+    // white surface; dark theme: lighten the accent so it isn't invisible on
+    // a nearly‑black surface.
+    return theme === 'light'
+      ? adjustLightness(merged.accentDefault, -0.15)
+      : adjustLightness(merged.accentDefault, 0.15);
+  })();
+
   const tokens: LucentTokens = {
     ...merged,
     textOnAccent: tokenOverrides?.textOnAccent ?? getContrastText(merged.accentDefault),
+    accentBorder: computedBorder,
   };
 
   // Set the root font size once so all rem-based tokens resolve to the intended scale.

--- a/src/tokens/color.ts
+++ b/src/tokens/color.ts
@@ -1,0 +1,130 @@
+// simple color helpers used by LucentProvider to generate derived tokens
+
+// convert hex #rrggbb to {r,g,b}
+function hexToRgb(hex: string) {
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  return { r, g, b };
+}
+
+// convert {r,g,b} to hex
+function rgbToHex({ r, g, b }: { r: number; g: number; b: number }): string {
+  const toHex = (n: number) => n.toString(16).padStart(2, '0');
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+}
+
+// convert hex to HSL (h in degrees, s/l between 0‑1)
+export function hexToHsl(hex: string): [number, number, number] {
+  const { r, g, b } = hexToRgb(hex);
+  const rr = r / 255;
+  const gg = g / 255;
+  const bb = b / 255;
+  const max = Math.max(rr, gg, bb);
+  const min = Math.min(rr, gg, bb);
+  let h = 0;
+  let s = 0;
+  const l = (max + min) / 2;
+
+  if (max !== min) {
+    const d = max - min;
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    switch (max) {
+      case rr:
+        h = (gg - bb) / d + (gg < bb ? 6 : 0);
+        break;
+      case gg:
+        h = (bb - rr) / d + 2;
+        break;
+      case bb:
+        h = (rr - gg) / d + 4;
+        break;
+    }
+    h /= 6;
+  }
+  return [h * 360, s, l];
+}
+
+// convert HSL back to hex
+export function hslToHex(h: number, s: number, l: number): string {
+  h = (h % 360 + 360) % 360; // ensure positive
+  s = Math.min(1, Math.max(0, s));
+  l = Math.min(1, Math.max(0, l));
+
+  const c = (1 - Math.abs(2 * l - 1)) * s;
+  const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+  const m = l - c / 2;
+  let r = 0,
+    g = 0,
+    b = 0;
+  if (h < 60) {
+    r = c;
+    g = x;
+  } else if (h < 120) {
+    r = x;
+    g = c;
+  } else if (h < 180) {
+    g = c;
+    b = x;
+  } else if (h < 240) {
+    g = x;
+    b = c;
+  } else if (h < 300) {
+    r = x;
+    b = c;
+  } else {
+    r = c;
+    b = x;
+  }
+  return rgbToHex({ r: Math.round((r + m) * 255), g: Math.round((g + m) * 255), b: Math.round((b + m) * 255) });
+}
+
+// shift lightness by a delta (-1 to 1). positive -> lighter, negative -> darker.
+export function adjustLightness(hex: string, delta: number): string {
+  const [h, s, l] = hexToHsl(hex);
+  return hslToHex(h, s, Math.min(1, Math.max(0, l + delta)));
+}
+
+// mix two hex colors; weight is fraction of first color (0..1)
+export function mix(hex1: string, hex2: string, weight: number): string {
+  const c1 = hexToRgb(hex1);
+  const c2 = hexToRgb(hex2);
+  const r = Math.round(c1.r * weight + c2.r * (1 - weight));
+  const g = Math.round(c1.g * weight + c2.g * (1 - weight));
+  const b = Math.round(c1.b * weight + c2.b * (1 - weight));
+  return rgbToHex({ r, g, b });
+}
+
+// calculate relative luminance of a color (0-1, where 0 is black, 1 is white)
+function getLuminance(hex: string): number {
+  const { r, g, b } = hexToRgb(hex);
+  const linearize = (c: number) => {
+    c = c / 255;
+    return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+  };
+  const rr = linearize(r);
+  const gg = linearize(g);
+  const bb = linearize(b);
+  return 0.2126 * rr + 0.7152 * gg + 0.0722 * bb;
+}
+
+// given a border color picked in one theme, generate the corresponding color for the other theme
+// preserves hue/saturation but inverts lightness with a lightness boost for dark theme readability
+export function getThemeComplementBorderColor(baseColor: string): string {
+  const [h, s, l] = hexToHsl(baseColor);
+  // invert lightness and boost it slightly to ensure dark theme borders aren't too dark
+  const invertedL = Math.min(1, (1 - l) + 0.15);
+  return hslToHex(h, s, invertedL);
+}
+
+// derive subtle and strong border variants from a default color
+export function deriveBorderVariants(baseColor: string): {
+  subtle: string;
+  strong: string;
+} {
+  const [h, s, l] = hexToHsl(baseColor);
+  return {
+    subtle: hslToHex(h, s, Math.max(0, l - 0.15)), // slightly darker
+    strong: hslToHex(h, s, Math.min(1, l + 0.15)), // slightly lighter
+  };
+}

--- a/src/tokens/dark.ts
+++ b/src/tokens/dark.ts
@@ -43,6 +43,8 @@ export const darkTokens: LucentTokens = {
   accentHover: '#e5e7eb',
   accentActive: '#d1d5db',
   accentSubtle: 'rgb(249 250 251 / 0.1)',
+  // placeholder — actual value is recomputed in LucentProvider
+  accentBorder: '#f9fafb',
 
   // Status
   successDefault: '#22c55e',

--- a/src/tokens/light.ts
+++ b/src/tokens/light.ts
@@ -43,6 +43,8 @@ export const lightTokens: LucentTokens = {
   accentHover: '#1f2937',
   accentActive: '#374151',
   accentSubtle: '#f3f4f6',
+  // placeholder — actual value is recomputed in LucentProvider
+  accentBorder: '#111827',
 
   // Status
   successDefault: '#16a34a',

--- a/src/tokens/types.ts
+++ b/src/tokens/types.ts
@@ -102,6 +102,11 @@ export interface SemanticColorTokens {
   accentHover: string;
   accentActive: string;
   accentSubtle: string;
+  // A slightly adjusted border color that pairs with `accentDefault`.
+  // Calculated automatically by `LucentProvider` so that a custom accent
+  // colour looks good on either light or dark backgrounds.
+  // Consumers may still override if they want precise control.
+  accentBorder: string;
   // Status
   successDefault: string;
   successSubtle: string;


### PR DESCRIPTION
- Add border color picker in customizer alongside accent color picker
- Implement smart color derivation that inverts lightness across themes
- When picking border color in light theme, automatically derives complement for dark theme
- Add theme-context-aware border color switching when theme toggles
- Export deriveBorderVariants and getThemeComplementBorderColor utilities
- Update components to use border tokens for consistent styling
- Add borderDefault, borderSubtle, borderStrong color pickers with manual/auto mode

The border customizer uses lightness inversion with a 0.15 boost to ensure dark mode borders remain visible while preserving hue and saturation.