### PR TITLE
feat(atoms): ColorSwatch, SegmentedControl, ColorPicker + Input/Select enhancements

### DIFF
--- a/.changeset/color-swatch-segmented-control-input.md
+++ b/.changeset/color-swatch-segmented-control-input.md
@@ -1,0 +1,17 @@
+---
+"lucent-ui": minor
+---
+
+Add ColorSwatch, SegmentedControl, ColorPicker atoms; enhance Input and Select
+
+**New atoms**
+- `ColorSwatch` — circular or square swatch with sizes (xs–2xl), selected state, checkerboard alpha support, and full button attribute forwarding
+- `SegmentedControl` — sliding active indicator, fullWidth default, sm/md/lg sizes
+- `ColorPicker` — spectrum panel, hue/alpha sliders, Hex/RGB/HSL/HSB format tabs, multi-group preset palettes, eyedropper support
+
+**Breaking changes**
+- `ColorPicker`: `presets`/`presetsLabel` props replaced by `presetGroups: ColorPresetGroup[]`
+
+**Enhancements**
+- `Input`: new `size` prop (sm/md/lg), `prefix`/`suffix` addons, `leftElement`/`rightElement` icon slots
+- `Select`: `style` prop now applies to the outer wrapper div (consistent with `Input`)


### PR DESCRIPTION
## Summary

- **New atom: `ColorSwatch`** — circle/square shape, xs–2xl sizes, `showCheckerboard` for alpha transparency, `selected` state with inset ring, full button attribute forwarding via `forwardRef`
- **New atom: `SegmentedControl`** — sliding active indicator, fullWidth default, sm/md/lg sizes
- **New atom: `ColorPicker`** — spectrum panel, hue/alpha sliders, Hex/RGB/HSL/HSB format tabs (SegmentedControl), multi-group preset palettes (Select switcher), eyedropper (Button), all sub-controls use library components
- **`Input` enhancements** — `size` prop (sm/md/lg), `prefix`/`suffix` addons, `leftElement`/`rightElement` icon slots
- **`Select` fix** — `style` prop now applies to outer wrapper div (consistent with `Input`)
- **Breaking**: `ColorPicker` `presets`/`presetsLabel` → `presetGroups: ColorPresetGroup[]`

## Test plan

- [ ] ColorSwatch renders all sizes/shapes, selected ring visible as inset shadow
- [ ] ColorSwatch `showCheckerboard` correctly shows transparency
- [ ] SegmentedControl sliding indicator animates on selection change
- [ ] ColorPicker opens/closes, all format tabs work, presets switchable via Select
- [ ] Input prefix/suffix render flush with field, focus ring on wrapper
- [ ] Select `style` prop affects outer wrapper, not inner `<select>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)