### PR TITLE
refine(Card): increase default padding sizes by ~1.5x

### DIFF
--- a/src/components/molecules/Card/Card.tsx
+++ b/src/components/molecules/Card/Card.tsx
@@ -16,9 +16,9 @@ export interface CardProps {
 
 const paddingMap: Record<CardPadding, string> = {
   none: '0',
-  sm:   'var(--lucent-space-3)',
-  md:   'var(--lucent-space-4)',
-  lg:   'var(--lucent-space-6)',
+  sm:   'var(--lucent-space-4)',
+  md:   'var(--lucent-space-6)',
+  lg:   'var(--lucent-space-8)',
 };
 
 const shadowMap: Record<CardShadow, string> = {


### PR DESCRIPTION
sm: space-3 → space-4, md: space-4 → space-6, lg: space-6 → space-8