### PR TITLE
feat(Tabs): add overflow menu for constrained-width tabs

### DIFF
--- a/dev/ComponentPreview.tsx
+++ b/dev/ComponentPreview.tsx
@@ -18,7 +18,7 @@ import { Icon } from '../src/components/atoms/Icon/index.js';
 import { Text } from '../src/components/atoms/Text/index.js';
 import { FormField } from '../src/components/molecules/FormField/index.js';
 import { SearchInput } from '../src/components/molecules/SearchInput/index.js';
-import { Card } from '../src/components/molecules/Card/index.js';
+import { Card, CardBleed } from '../src/components/molecules/Card/index.js';
 import { Alert } from '../src/components/molecules/Alert/index.js';
 import { EmptyState } from '../src/components/molecules/EmptyState/index.js';
 import { Skeleton } from '../src/components/molecules/Skeleton/index.js';
@@ -726,6 +726,40 @@ function Inner({
             <Text size="xs">lg padding + shadow</Text>
           </Card>
         </Row>
+        <Row label="CardBleed" tokens={tokens}>
+          <Card style={{ width: 320 }}>
+            <Text weight="semibold" size="sm">Settings</Text>
+            <CardBleed
+              style={{
+                borderTop: `1px solid ${tokens.borderDefault}`,
+                borderBottom: `1px solid ${tokens.borderDefault}`,
+                marginTop: tokens.space3,
+                paddingTop: tokens.space3,
+                paddingBottom: tokens.space3,
+              }}
+            >
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                <Text size="sm">Email alerts</Text>
+                <Toggle checked onChange={() => {}} />
+              </div>
+            </CardBleed>
+            <CardBleed
+              style={{
+                borderBottom: `1px solid ${tokens.borderDefault}`,
+                paddingTop: tokens.space3,
+                paddingBottom: tokens.space3,
+              }}
+            >
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                <Text size="sm">Push notifications</Text>
+                <Toggle onChange={() => {}} />
+              </div>
+            </CardBleed>
+            <div style={{ paddingTop: tokens.space3 }}>
+              <Text size="xs" color="secondary">Bleed rows stretch edge-to-edge.</Text>
+            </div>
+          </Card>
+        </Row>
       </Section>
 
       {/* Alert */}
@@ -1306,7 +1340,7 @@ function Inner({
       </Section>
 
       <Section title="Tabs" tokens={tokens}>
-        <Row label="Default" tokens={tokens}>
+        <Row label="Underline (default)" tokens={tokens}>
           <div style={{ width: '100%' }}>
             <Tabs
               tabs={[
@@ -1314,6 +1348,33 @@ function Inner({
                 { value: 'api', label: 'API', content: <Text size="sm" color="secondary">API reference content.</Text> },
                 { value: 'examples', label: 'Examples', content: <Text size="sm" color="secondary">Usage examples.</Text> },
                 { value: 'disabled', label: 'Disabled', content: null, disabled: true },
+              ]}
+            />
+          </div>
+        </Row>
+        <Row label="Pills" tokens={tokens}>
+          <div style={{ width: '100%' }}>
+            <Tabs
+              variant="pills"
+              tabs={[
+                { value: 'overview', label: 'Overview', content: <Text size="sm" color="secondary">Overview content goes here.</Text> },
+                { value: 'api', label: 'API', content: <Text size="sm" color="secondary">API reference content.</Text> },
+                { value: 'examples', label: 'Examples', content: <Text size="sm" color="secondary">Usage examples.</Text> },
+                { value: 'disabled', label: 'Disabled', content: null, disabled: true },
+              ]}
+            />
+          </div>
+        </Row>
+        <Row label="Overflow (constrained width)" tokens={tokens}>
+          <div style={{ width: 360 }}>
+            <Tabs
+              tabs={[
+                { value: 'overview', label: 'Overview', content: <Text size="sm" color="secondary">Overview content.</Text> },
+                { value: 'api', label: 'API', content: <Text size="sm" color="secondary">API reference.</Text> },
+                { value: 'examples', label: 'Examples', content: <Text size="sm" color="secondary">Usage examples.</Text> },
+                { value: 'changelog', label: 'Changelog', content: <Text size="sm" color="secondary">Changelog content.</Text> },
+                { value: 'settings', label: 'Settings', content: <Text size="sm" color="secondary">Settings content.</Text> },
+                { value: 'advanced', label: 'Advanced', content: <Text size="sm" color="secondary">Advanced options.</Text> },
               ]}
             />
           </div>

--- a/src/components/molecules/Tabs/Tabs.tsx
+++ b/src/components/molecules/Tabs/Tabs.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useLayoutEffect, type CSSProperties, type ReactNode, type KeyboardEvent } from 'react';
+import { useState, useRef, useLayoutEffect, useEffect, type CSSProperties, type ReactNode, type KeyboardEvent } from 'react';
 
 export interface TabItem {
   value: string;
@@ -7,15 +7,18 @@ export interface TabItem {
   disabled?: boolean;
 }
 
+export type TabsVariant = 'underline' | 'pills';
+
 export interface TabsProps {
   tabs: TabItem[];
   defaultValue?: string;
   value?: string;
   onChange?: (value: string) => void;
+  variant?: TabsVariant;
   style?: CSSProperties;
 }
 
-export function Tabs({ tabs, defaultValue, value, onChange, style }: TabsProps) {
+export function Tabs({ tabs, defaultValue, value, onChange, variant = 'underline', style }: TabsProps) {
   const isControlled = value !== undefined;
   const [internalValue, setInternalValue] = useState(defaultValue ?? tabs[0]?.value ?? '');
   const activeValue = isControlled ? value! : internalValue;
@@ -25,13 +28,129 @@ export function Tabs({ tabs, defaultValue, value, onChange, style }: TabsProps) 
   const [indicator, setIndicator] = useState<{ left: number; width: number; animate: boolean } | null>(null);
   const mounted = useRef(false);
 
-  useLayoutEffect(() => {
-    const activeIdx = tabs.findIndex(t => t.value === activeValue);
+  const isPills = variant === 'pills';
+
+  // Overflow state
+  const tablistRef = useRef<HTMLDivElement | null>(null);
+  const moreButtonRef = useRef<HTMLButtonElement | null>(null);
+  const dropdownRef = useRef<HTMLDivElement | null>(null);
+  const [visibleCount, setVisibleCount] = useState(tabs.length);
+  const [moreOpen, setMoreOpen] = useState(false);
+  const [moreHovered, setMoreHovered] = useState(false);
+  const [dropdownHoveredIndex, setDropdownHoveredIndex] = useState<number | null>(null);
+
+  const visibleTabs = tabs.slice(0, visibleCount);
+  const overflowTabs = tabs.slice(visibleCount);
+  const hasOverflow = overflowTabs.length > 0;
+  // If the active tab is in overflow, we still need to know for the panel rendering
+  const activeInOverflow = overflowTabs.some(t => t.value === activeValue);
+
+  const measure = () => {
+    if (activeInOverflow) {
+      setIndicator(null);
+      return;
+    }
+    const activeIdx = tabs.findIndex((t, i) => i < visibleCount && t.value === activeValue);
     const el = tabRefs.current[activeIdx];
     if (!el) return;
-    setIndicator({ left: el.offsetLeft, width: el.offsetWidth, animate: mounted.current });
+    if (isPills) {
+      const inner = el.querySelector('span') as HTMLElement | null;
+      if (!inner) return;
+      setIndicator({ left: inner.offsetLeft + el.offsetLeft, width: inner.offsetWidth, animate: mounted.current });
+    } else {
+      setIndicator({ left: el.offsetLeft, width: el.offsetWidth, animate: mounted.current });
+    }
     mounted.current = true;
-  }, [activeValue, tabs]);
+  };
+
+  useLayoutEffect(() => {
+    measure();
+    document.fonts.ready.then(measure);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeValue, visibleCount, isPills]);
+
+  // Overflow measurement
+  useEffect(() => {
+    const tablist = tablistRef.current;
+    if (!tablist) return;
+
+    const computeOverflow = () => {
+      const containerWidth = tablist.clientWidth;
+      // Estimate "More..." button width (~70px)
+      const moreWidth = 70;
+      let usedWidth = 0;
+      let count = 0;
+
+      for (let i = 0; i < tabs.length; i++) {
+        const el = tabRefs.current[i];
+        if (!el) {
+          // Tab element not rendered yet — assume it fits
+          count++;
+          continue;
+        }
+        const w = el.offsetWidth;
+        if (i < tabs.length - 1) {
+          // Need room for this tab + more button
+          if (usedWidth + w + moreWidth > containerWidth) break;
+        } else {
+          // Last tab — no more button needed if it fits
+          if (usedWidth + w > containerWidth) break;
+        }
+        usedWidth += w;
+        count++;
+      }
+
+      // If only 1 or 0 overflow, show all (avoid "More..." for just 1 item)
+      if (count >= tabs.length - 1 && count < tabs.length) {
+        // Check if all tabs actually fit without the more button
+        let totalWidth = 0;
+        for (let i = 0; i < tabs.length; i++) {
+          const el = tabRefs.current[i];
+          if (el) totalWidth += el.offsetWidth;
+        }
+        if (totalWidth <= containerWidth) {
+          count = tabs.length;
+        }
+      }
+
+      setVisibleCount(count < 1 ? 1 : count);
+    };
+
+    // We need all tabs rendered to measure — render all first, then compute
+    // Use a double rAF to ensure layout is complete
+    let frameId: number;
+    const deferredCompute = () => {
+      frameId = requestAnimationFrame(() => {
+        frameId = requestAnimationFrame(computeOverflow);
+      });
+    };
+
+    deferredCompute();
+
+    const ro = new ResizeObserver(computeOverflow);
+    ro.observe(tablist);
+
+    return () => {
+      ro.disconnect();
+      cancelAnimationFrame(frameId);
+    };
+  }, [tabs]);
+
+  // Close dropdown on click outside
+  useEffect(() => {
+    if (!moreOpen) return;
+    const handleClick = (e: MouseEvent) => {
+      if (
+        dropdownRef.current && !dropdownRef.current.contains(e.target as Node) &&
+        moreButtonRef.current && !moreButtonRef.current.contains(e.target as Node)
+      ) {
+        setMoreOpen(false);
+        setDropdownHoveredIndex(null);
+      }
+    };
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [moreOpen]);
 
   const activate = (val: string) => {
     if (!isControlled) setInternalValue(val);
@@ -39,7 +158,7 @@ export function Tabs({ tabs, defaultValue, value, onChange, style }: TabsProps) 
   };
 
   const handleKeyDown = (e: KeyboardEvent<HTMLButtonElement>, idx: number) => {
-    const enabledIndexes = tabs.map((t, i) => (!t.disabled ? i : -1)).filter((i): i is number => i !== -1);
+    const enabledIndexes = visibleTabs.map((t, i) => (!t.disabled ? i : -1)).filter((i): i is number => i !== -1);
     const pos = enabledIndexes.indexOf(idx);
     let next = -1;
     if (e.key === 'ArrowRight') next = enabledIndexes[(pos + 1) % enabledIndexes.length] ?? -1;
@@ -49,22 +168,35 @@ export function Tabs({ tabs, defaultValue, value, onChange, style }: TabsProps) 
     if (next !== -1) {
       e.preventDefault();
       tabRefs.current[next]?.focus();
-      activate(tabs[next]!.value);
+      activate(visibleTabs[next]!.value);
     }
   };
 
+  // For overflow measurement, we render hidden tabs off-screen to measure their widths.
+  // But we only need this when visibleCount < tabs.length on first pass.
+  // Instead, we render all tabs but hide overflow ones via display:none after measurement.
+
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', ...style }}>
+    <div style={{ display: 'flex', flexDirection: 'column', position: 'relative', ...style }}>
       {/* Tab list */}
       <div
+        ref={tablistRef}
         role="tablist"
         style={{
           position: 'relative',
           display: 'flex',
-          borderBottom: '1px solid var(--lucent-border-default)',
+          overflow: 'hidden',
+          ...(isPills
+            ? {
+                padding: 'var(--lucent-space-1)',
+              }
+            : {
+                borderBottom: '1px solid var(--lucent-border-default)',
+              }),
         }}
       >
         {tabs.map((tab, i) => {
+          const isVisible = i < visibleCount;
           const isActive = tab.value === activeValue;
           const isDisabled = tab.disabled ?? false;
           return (
@@ -76,13 +208,15 @@ export function Tabs({ tabs, defaultValue, value, onChange, style }: TabsProps) 
               aria-controls={`lucent-tabpanel-${tab.value}`}
               id={`lucent-tab-${tab.value}`}
               disabled={isDisabled}
-              tabIndex={isActive ? 0 : -1}
+              tabIndex={isActive && isVisible ? 0 : -1}
               onClick={() => { if (!isDisabled) activate(tab.value); }}
               onKeyDown={(e) => handleKeyDown(e, i)}
-              onMouseEnter={() => { if (!isDisabled) setHoveredIndex(i); }}
+              onMouseEnter={() => { if (!isDisabled && isVisible) setHoveredIndex(i); }}
               onMouseLeave={() => setHoveredIndex(null)}
               style={{
-                padding: 'var(--lucent-space-1) var(--lucent-space-2) var(--lucent-space-3)',
+                padding: isPills
+                  ? 'var(--lucent-space-1) var(--lucent-space-2)'
+                  : 'var(--lucent-space-1) var(--lucent-space-2) var(--lucent-space-3)',
                 background: 'none',
                 border: 'none',
                 cursor: isDisabled ? 'not-allowed' : 'pointer',
@@ -91,34 +225,106 @@ export function Tabs({ tabs, defaultValue, value, onChange, style }: TabsProps) 
                 fontWeight: isActive ? 'var(--lucent-font-weight-medium)' : 'var(--lucent-font-weight-regular)',
                 color: isDisabled
                   ? 'var(--lucent-text-disabled)'
+                  : isPills && isActive
+                  ? 'var(--lucent-text-on-accent)'
                   : isActive
                   ? 'var(--lucent-text-primary)'
                   : 'var(--lucent-text-secondary)',
                 transition: 'color var(--lucent-duration-fast) var(--lucent-easing-default)',
                 whiteSpace: 'nowrap',
                 outline: 'none',
+                position: isVisible ? 'relative' : 'absolute',
+                zIndex: isActive ? 1 : 0,
+                // Hidden overflow tabs are positioned off-screen for measurement
+                ...(isVisible ? {} : { visibility: 'hidden' as const, pointerEvents: 'none' as const, left: -9999 }),
               }}
             >
               <span style={{
                 display: 'block',
                 padding: 'var(--lucent-space-1) var(--lucent-space-3)',
                 borderRadius: 'var(--lucent-radius-md)',
-                background: hoveredIndex === i && !isActive
+                background: !isPills && hoveredIndex === i && !isActive && !isDisabled
                   ? 'var(--lucent-surface-secondary)'
                   : 'transparent',
                 transition: 'background var(--lucent-duration-fast) var(--lucent-easing-default)',
               }}>
                 {tab.label}
               </span>
+              {/* Pills hover background — matches accent pill height */}
+              {isPills && hoveredIndex === i && !isActive && !isDisabled && isVisible && (
+                <span
+                  aria-hidden
+                  style={{
+                    position: 'absolute',
+                    top: 0,
+                    bottom: 0,
+                    left: 0,
+                    right: 0,
+                    borderRadius: 'var(--lucent-radius-md)',
+                    background: 'var(--lucent-surface-secondary)',
+                    zIndex: -1,
+                    transition: 'background var(--lucent-duration-fast) var(--lucent-easing-default)',
+                  }}
+                />
+              )}
             </button>
           );
         })}
+
+        {/* More button */}
+        {hasOverflow && (
+          <button
+            ref={moreButtonRef}
+            onClick={() => setMoreOpen(v => !v)}
+            onMouseEnter={() => setMoreHovered(true)}
+            onMouseLeave={() => setMoreHovered(false)}
+            style={{
+              padding: isPills
+                ? 'var(--lucent-space-1) var(--lucent-space-2)'
+                : 'var(--lucent-space-1) var(--lucent-space-2) var(--lucent-space-3)',
+              background: 'none',
+              border: 'none',
+              cursor: 'pointer',
+              fontFamily: 'var(--lucent-font-family-base)',
+              fontSize: 'var(--lucent-font-size-md)',
+              fontWeight: activeInOverflow ? 'var(--lucent-font-weight-medium)' : 'var(--lucent-font-weight-regular)',
+              color: activeInOverflow ? 'var(--lucent-text-primary)' : 'var(--lucent-text-secondary)',
+              whiteSpace: 'nowrap',
+              outline: 'none',
+              position: 'relative',
+              flexShrink: 0,
+            }}
+          >
+            <span style={{
+              display: 'block',
+              padding: 'var(--lucent-space-1) var(--lucent-space-3)',
+              borderRadius: 'var(--lucent-radius-md)',
+              background: moreHovered
+                ? 'var(--lucent-surface-secondary)'
+                : 'transparent',
+              transition: 'background var(--lucent-duration-fast) var(--lucent-easing-default)',
+            }}>
+              More…
+            </span>
+          </button>
+        )}
 
         {/* Sliding indicator */}
         {indicator != null && (
           <span
             aria-hidden
-            style={{
+            style={isPills ? {
+              position: 'absolute',
+              top: 'var(--lucent-space-1)',
+              bottom: 'var(--lucent-space-1)',
+              left: indicator.left,
+              width: indicator.width,
+              background: 'var(--lucent-accent-default)',
+              borderRadius: 'var(--lucent-radius-md)',
+              transition: indicator.animate
+                ? 'left 220ms var(--lucent-easing-default), width 220ms var(--lucent-easing-default)'
+                : 'none',
+            } : {
               position: 'absolute',
               bottom: 0,
               left: indicator.left,
@@ -133,6 +339,71 @@ export function Tabs({ tabs, defaultValue, value, onChange, style }: TabsProps) 
           />
         )}
       </div>
+
+      {/* Overflow dropdown */}
+      {hasOverflow && moreOpen && (
+        <div
+          ref={dropdownRef}
+          style={{
+            position: 'absolute',
+            top: '100%',
+            right: 0,
+            zIndex: 50,
+            marginTop: 'var(--lucent-space-1)',
+            background: 'var(--lucent-surface-primary)',
+            border: '1px solid var(--lucent-border-default)',
+            borderRadius: 'var(--lucent-radius-md)',
+            boxShadow: 'var(--lucent-shadow-md)',
+            padding: 'var(--lucent-space-1) 0',
+            minWidth: 140,
+          }}
+        >
+          {overflowTabs.map((tab, i) => {
+            const isActive = tab.value === activeValue;
+            const isDisabled = tab.disabled ?? false;
+            const isHovered = dropdownHoveredIndex === i;
+            return (
+              <button
+                key={tab.value}
+                disabled={isDisabled}
+                onClick={() => {
+                  if (!isDisabled) {
+                    activate(tab.value);
+                    setMoreOpen(false);
+                  }
+                }}
+                onMouseEnter={() => { if (!isDisabled) setDropdownHoveredIndex(i); }}
+                onMouseLeave={() => setDropdownHoveredIndex(null)}
+                style={{
+                  display: 'block',
+                  width: '100%',
+                  padding: 'var(--lucent-space-2) var(--lucent-space-4)',
+                  background: isActive
+                    ? 'var(--lucent-surface-secondary)'
+                    : isHovered
+                    ? 'var(--lucent-surface-secondary)'
+                    : 'none',
+                  border: 'none',
+                  cursor: isDisabled ? 'not-allowed' : 'pointer',
+                  fontFamily: 'var(--lucent-font-family-base)',
+                  fontSize: 'var(--lucent-font-size-md)',
+                  fontWeight: isActive ? 'var(--lucent-font-weight-medium)' : 'var(--lucent-font-weight-regular)',
+                  color: isDisabled
+                    ? 'var(--lucent-text-disabled)'
+                    : isActive || isHovered
+                    ? 'var(--lucent-text-primary)'
+                    : 'var(--lucent-text-secondary)',
+                  textAlign: 'left',
+                  outline: 'none',
+                  transition: 'background var(--lucent-duration-fast) var(--lucent-easing-default), color var(--lucent-duration-fast) var(--lucent-easing-default)',
+                }}
+              >
+                {tab.label}
+              </button>
+            );
+          })}
+        </div>
+      )}
 
       {/* Tab panels */}
       {tabs.map((tab) => (


### PR DESCRIPTION
When tabs exceed the available container width, a "More…" button appears with a dropdown listing the overflow items. Uses ResizeObserver for responsive recalculation, click-outside dismissal, hover states, and proper z-index stacking.