### PR TITLE
feat(Card): add CardBleed for edge-to-edge content

### DIFF
--- a/src/components/molecules/Card/Card.manifest.ts
+++ b/src/components/molecules/Card/Card.manifest.ts
@@ -7,7 +7,7 @@ export const COMPONENT_MANIFEST: ComponentManifest = {
   domain: 'neutral',
   specVersion: '0.1',
 
-  description: 'A surface container with optional header, body, and footer slots, configurable padding, shadow, and radius.',
+  description: 'A surface container with optional header, body, and footer slots, configurable padding, shadow, and radius. Includes a CardBleed sub-component for edge-to-edge content.',
 
   designIntent:
     'Card provides a consistent elevated surface for grouping related content. The header and footer slots ' +
@@ -15,6 +15,10 @@ export const COMPONENT_MANIFEST: ComponentManifest = {
     'the consumer to manage spacing. Padding, shadow, and radius are all configurable to accommodate ' +
     'flat/ghost cards, modal-like surfaces, and compact data-dense layouts. The overflow: hidden ensures ' +
     'children respect the border-radius without needing additional clipping.\n\n' +
+    'CardBleed is a companion component that allows specific children within the Card body to stretch ' +
+    'edge-to-edge, cancelling the horizontal padding via negative margins. Text inside CardBleed stays ' +
+    'aligned with the rest of the card content thanks to matching inner padding. Use it for dividers, ' +
+    'full-width lists, or bordered sections that need to reach the card edges.\n\n' +
     'Token rule: Card uses surface for its background. Never use bgBase or bgSubtle on a Card — ' +
     'those tokens are reserved for the page canvas (body, sidebar, layout regions). Content nested ' +
     'inside a Card that needs a tinted fill (e.g. a footer, inset panel, or disabled input) should use ' +
@@ -91,6 +95,15 @@ export const COMPONENT_MANIFEST: ComponentManifest = {
       title: 'Flat variant',
       code: `<Card shadow="none" radius="sm" padding="sm">
   <Text size="sm">Compact flat card</Text>
+</Card>`,
+    },
+    {
+      title: 'Edge-to-edge content with CardBleed',
+      code: `<Card>
+  <Text weight="semibold">Settings</Text>
+  <CardBleed style={{ borderTop: '1px solid var(--lucent-border-default)', marginTop: 'var(--lucent-space-4)' }}>
+    <Text color="secondary">This section stretches to the card edges.</Text>
+  </CardBleed>
 </Card>`,
     },
   ],

--- a/src/components/molecules/Card/Card.tsx
+++ b/src/components/molecules/Card/Card.tsx
@@ -1,3 +1,4 @@
+import { createContext, useContext } from 'react';
 import type { CSSProperties, ReactNode } from 'react';
 
 export type CardPadding = 'none' | 'sm' | 'md' | 'lg';
@@ -13,6 +14,13 @@ export interface CardProps {
   radius?: CardRadius;
   style?: CSSProperties;
 }
+
+export interface CardBleedProps {
+  children: ReactNode;
+  style?: CSSProperties;
+}
+
+const CardPaddingContext = createContext<string>('0');
 
 const paddingMap: Record<CardPadding, string> = {
   none: '0',
@@ -71,9 +79,11 @@ export function Card({
           {header}
         </div>
       )}
-      <div style={{ padding: p, flex: 1 }}>
-        {children}
-      </div>
+      <CardPaddingContext.Provider value={p}>
+        <div style={{ padding: p, flex: 1 }}>
+          {children}
+        </div>
+      </CardPaddingContext.Provider>
       {footer != null && (
         <div
           style={{
@@ -84,6 +94,24 @@ export function Card({
           {footer}
         </div>
       )}
+    </div>
+  );
+}
+
+export function CardBleed({ children, style }: CardBleedProps) {
+  const p = useContext(CardPaddingContext);
+
+  return (
+    <div
+      style={{
+        marginLeft: `calc(-1 * ${p})`,
+        marginRight: `calc(-1 * ${p})`,
+        paddingLeft: p,
+        paddingRight: p,
+        ...style,
+      }}
+    >
+      {children}
     </div>
   );
 }

--- a/src/components/molecules/Card/index.ts
+++ b/src/components/molecules/Card/index.ts
@@ -1,3 +1,3 @@
-export { Card } from './Card.js';
-export type { CardProps, CardPadding, CardShadow, CardRadius } from './Card.js';
+export { Card, CardBleed } from './Card.js';
+export type { CardProps, CardBleedProps, CardPadding, CardShadow, CardRadius } from './Card.js';
 export { COMPONENT_MANIFEST as CardManifest } from './Card.manifest.js';


### PR DESCRIPTION
## Summary
- Adds `CardBleed` companion component that cancels horizontal Card body padding via negative margins, allowing content (dividers, lists, bordered sections) to stretch edge-to-edge
- Card body now provides its padding value through React context so `CardBleed` adapts automatically to any padding size
- Updated Card manifest with CardBleed design intent documentation and usage example

## Test plan
- [ ] Verify `CardBleed` children stretch to card edges at all padding sizes (`sm`, `md`, `lg`)
- [ ] Verify text inside `CardBleed` stays aligned with normal card content
- [ ] Verify `CardBleed` outside a Card falls back gracefully (renders with `0` padding context)
- [ ] Check ComponentPreview CardBleed row renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)