### PR TITLE
feat: add danger-outline and danger-ghost Button variants

### DIFF
--- a/dev/ComponentPreview.tsx
+++ b/dev/ComponentPreview.tsx
@@ -1565,7 +1565,8 @@ function Inner({
           <Button variant="outline">Outline</Button>
           <Button variant="ghost">Ghost</Button>
           <Button variant="danger">Danger</Button>
-
+          <Button variant="danger-outline">Danger outline</Button>
+          <Button variant="danger-ghost">Danger ghost</Button>
         </Row>
         <Row label="Pressed" tokens={tokens}>
           {(['primary', 'secondary', 'outline', 'ghost', 'danger'] as const).map((v) => (
@@ -1592,6 +1593,8 @@ function Inner({
           <Button size="2xs" variant="outline" leftIcon={<SmallIcon d="M18 6L6 18M6 6l12 12" />} aria-label="Close" />
           <Button size="2xs" variant="secondary" leftIcon={<SmallIcon d="M12 20h9M16.5 3.5a2.12 2.12 0 013 3L7 19l-4 1 1-4z" />} aria-label="Edit" />
           <Button size="2xs" variant="danger" leftIcon={<SmallIcon d="M3 6h18M8 6V4h8v2M19 6l-1 14H6L5 6" />} aria-label="Delete" />
+          <Button size="2xs" variant="danger-outline" leftIcon={<SmallIcon d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0zM12 9v4M12 17h.01" />} aria-label="Warn" />
+          <Button size="2xs" variant="danger-ghost" leftIcon={<SmallIcon d="M18 6L6 18M6 6l12 12" />} aria-label="Remove" />
         </Row>
         <Row label="Icons" tokens={tokens}>
           <Button leftIcon={<StarIcon />}>With prefix</Button>

--- a/src/components/atoms/Button/Button.tsx
+++ b/src/components/atoms/Button/Button.tsx
@@ -1,6 +1,6 @@
 import { forwardRef, type ButtonHTMLAttributes, type CSSProperties, type ReactNode } from 'react';
 
-export type ButtonVariant = 'primary' | 'secondary' | 'outline' | 'ghost' | 'danger';
+export type ButtonVariant = 'primary' | 'secondary' | 'outline' | 'ghost' | 'danger' | 'danger-outline' | 'danger-ghost';
 export type ButtonSize = '2xs' | 'xs' | 'sm' | 'md' | 'lg';
 
 export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
@@ -45,6 +45,16 @@ const variantStyles: Record<ButtonVariant, CSSProperties> = {
     background: 'var(--lucent-danger-default)',
     color: '#ffffff',
     border: '1px solid var(--lucent-danger-default)',
+  },
+  'danger-outline': {
+    background: 'var(--lucent-surface)',
+    color: 'var(--lucent-danger-text)',
+    border: '1px solid var(--lucent-danger-default)',
+  },
+  'danger-ghost': {
+    background: 'transparent',
+    color: 'var(--lucent-danger-text)',
+    border: '1px solid transparent',
   },
 };
 
@@ -103,7 +113,8 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         }}
         onMouseDown={(e) => {
           if (!isDisabled) {
-            const ring = variant === 'danger' ? 'var(--lucent-danger-default)' : 'var(--lucent-accent-default)';
+            const isDanger = variant === 'danger' || variant === 'danger-outline' || variant === 'danger-ghost';
+            const ring = isDanger ? 'var(--lucent-danger-default)' : 'var(--lucent-accent-default)';
             e.currentTarget.style.transform = 'translateY(1px)';
             e.currentTarget.style.boxShadow = `0 0 0 2px var(--lucent-surface), 0 0 0 4px ${ring}`;
             e.currentTarget.dataset.pressed = '1';
@@ -140,11 +151,13 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
 Button.displayName = 'Button';
 
 const hoverShadow: Record<ButtonVariant, string> = {
-  primary:   '0 4px 14px -2px var(--lucent-accent-subtle)',
-  secondary: '0 4px 14px -2px var(--lucent-accent-subtle)',
-  outline:   '0 4px 14px -2px var(--lucent-accent-subtle)',
-  ghost:     '0 4px 14px -2px var(--lucent-accent-subtle)',
-  danger:    '0 4px 14px -2px var(--lucent-danger-subtle)',
+  primary:          '0 4px 14px -2px var(--lucent-accent-subtle)',
+  secondary:        '0 4px 14px -2px var(--lucent-accent-subtle)',
+  outline:          '0 4px 14px -2px var(--lucent-accent-subtle)',
+  ghost:            '0 4px 14px -2px var(--lucent-accent-subtle)',
+  danger:           '0 4px 14px -2px var(--lucent-danger-subtle)',
+  'danger-outline': '0 4px 14px -2px var(--lucent-danger-subtle)',
+  'danger-ghost':   '0 4px 14px -2px var(--lucent-danger-subtle)',
 };
 
 function applyHover(el: HTMLButtonElement, variant: ButtonVariant, bordered?: boolean) {
@@ -162,6 +175,11 @@ function applyHover(el: HTMLButtonElement, variant: ButtonVariant, bordered?: bo
   } else if (variant === 'danger') {
     el.style.background = 'var(--lucent-danger-hover)';
     if (bordered !== false) el.style.borderColor = 'var(--lucent-danger-hover)';
+  } else if (variant === 'danger-outline') {
+    el.style.background = 'color-mix(in srgb, var(--lucent-danger-default) 10%, var(--lucent-surface))';
+    if (bordered !== false) el.style.borderColor = 'var(--lucent-danger-hover)';
+  } else if (variant === 'danger-ghost') {
+    el.style.background = 'color-mix(in srgb, var(--lucent-danger-default) 8%, var(--lucent-surface))';
   }
 }
 
@@ -180,6 +198,11 @@ function removeHover(el: HTMLButtonElement, variant: ButtonVariant, bordered?: b
   } else if (variant === 'danger') {
     el.style.background = 'var(--lucent-danger-default)';
     if (bordered !== false) el.style.borderColor = 'var(--lucent-danger-default)';
+  } else if (variant === 'danger-outline') {
+    el.style.background = 'var(--lucent-surface)';
+    if (bordered !== false) el.style.borderColor = 'var(--lucent-danger-default)';
+  } else if (variant === 'danger-ghost') {
+    el.style.background = 'transparent';
   }
 }
 

--- a/src/manifest/examples/button.manifest.ts
+++ b/src/manifest/examples/button.manifest.ts
@@ -12,7 +12,8 @@ export const ButtonManifest: ComponentManifest = {
     'Buttons communicate available actions. Variant conveys hierarchy: use "primary" for the ' +
     'single most important action in a view, "secondary" for supporting actions, "ghost" for ' +
     'low-emphasis actions in dense UIs, "outline" for bordered buttons with no fill, and "danger" exclusively for destructive or irreversible ' +
-    'operations. Size should match surrounding content density — prefer "md" as the default, ' +
+    'operations. Use "danger-ghost" for low-emphasis destructive actions (red text, no fill) and ' +
+    '"danger-outline" for bordered destructive buttons. Size should match surrounding content density — prefer "md" as the default, ' +
     '"sm" for toolbars or tables, "xs" for compact UIs like customizer panels, and "2xs" for ' +
     'ultra-dense inline controls (~22px height) such as table-inline actions or toolbar icon triggers.',
   props: [
@@ -21,15 +22,29 @@ export const ButtonManifest: ComponentManifest = {
       type: 'enum',
       required: false,
       default: 'primary',
-      description: 'Visual style conveying action hierarchy.',
-      enumValues: ['primary', 'secondary', 'outline', 'ghost', 'danger'],
+      description:
+        'Visual style conveying action hierarchy. ' +
+        '"primary" — filled accent for the single most important action. ' +
+        '"secondary" — subtle accent-tinted fill for supporting actions. ' +
+        '"outline" — bordered with no fill, for neutral secondary actions. ' +
+        '"ghost" — transparent with no border, for low-emphasis or inline actions. ' +
+        '"danger" — filled red for irreversible destructive actions (e.g. "Delete account"). ' +
+        '"danger-outline" — red border + red text for destructive actions that need visual weight without a filled background. ' +
+        '"danger-ghost" — red text only, for low-emphasis destructive actions (e.g. "Remove" in a list row).',
+      enumValues: ['primary', 'secondary', 'outline', 'ghost', 'danger', 'danger-outline', 'danger-ghost'],
     },
     {
       name: 'size',
       type: 'enum',
       required: false,
       default: 'md',
-      description: 'Controls height and padding.',
+      description:
+        'Controls height and padding. ' +
+        '"lg" (48px) — hero sections, onboarding flows. ' +
+        '"md" (42px) — default for most forms and dialogs. ' +
+        '"sm" (34px) — toolbars, table headers, card actions. ' +
+        '"xs" (26px) — compact UIs like customizer panels, inline controls. ' +
+        '"2xs" (22px) — ultra-dense inline icon triggers, table-row actions, dashboard toolbar buttons.',
       enumValues: ['2xs', 'xs', 'sm', 'md', 'lg'],
     },
     {
@@ -139,6 +154,14 @@ export const ButtonManifest: ComponentManifest = {
     {
       title: 'Dropdown trigger',
       code: `<Button variant="outline" chevron>Options</Button>`,
+    },
+    {
+      title: 'Bordered destructive action',
+      code: `<Button variant="danger-outline" onClick={handleRevoke}>Revoke access</Button>`,
+    },
+    {
+      title: 'Low-emphasis destructive action',
+      code: `<Button variant="danger-ghost" onClick={handleRemove}>Remove</Button>`,
     },
     {
       title: 'Dense inline action',


### PR DESCRIPTION
## Summary
- Adds `variant="danger-outline"` — red border + red text on surface background
- Adds `variant="danger-ghost"` — red text on transparent background, no border
- All danger variants share danger-colored hover shadow, press ring, and focus ring
- Expanded manifest descriptions with per-value usage guidance for variant and size props
- Dev preview updated with new variants in showcase and icon-only rows

## Test plan
- [ ] Verify `danger-outline` shows red border + red text, subtle red bg tint on hover
- [ ] Verify `danger-ghost` shows red text only, subtle red bg tint on hover
- [ ] Verify press ring uses danger color for both new variants
- [ ] Verify disabled state applies neutral gray to both new variants

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)