### PR TITLE
feat: add Stack and Row layout primitives

### DIFF
--- a/dev/ComponentPreview.tsx
+++ b/dev/ComponentPreview.tsx
@@ -53,6 +53,8 @@ import { ToastProvider, useToast, type ToastPosition } from '../src/components/m
 import { ColorPicker, type ColorPresetGroup } from '../src/components/atoms/ColorPicker/index.js';
 import { ColorSwatch } from '../src/components/atoms/ColorSwatch/index.js';
 import { SegmentedControl } from '../src/components/atoms/SegmentedControl/index.js';
+import { Stack as StackAtom } from '../src/components/atoms/Stack/index.js';
+import { Row as RowAtom } from '../src/components/atoms/Row/index.js';
 import type { LucentTokens, Theme, ThemeAnchors, UploadFile } from '../src/index.js';
 
 // ─── Palette map ────────────────────────────────────────────────────────────
@@ -400,6 +402,7 @@ function Inner({
     'Tooltip', 'Icon', 'Button', 'Avatar', 'Spinner', 'Divider',
     'Breadcrumb', 'Tabs', 'Collapsible', 'NavLink', 'PageLayout', 'DataTable',
     'CommandPalette', 'MultiSelect', 'DatePicker', 'DateRangePicker', 'FileUpload', 'Timeline', 'Menu', 'Toast',
+    'Stack', 'Row',
   ];
 
   const filterLower = componentFilter.toLowerCase();
@@ -2177,6 +2180,77 @@ function Inner({
           <ToastButtons position={toastPosition} onChangePosition={onChangeToastPosition} />
         </Row>
       </Section>
+
+      {/* Stack */}
+      <Section title="Stack" tokens={tokens} hidden={!showSection('Stack')}>
+        <Row label="Vertical spacing" tokens={tokens}>
+          <StackAtom gap="3" style={{ padding: tokens.space4, background: tokens.surfaceSecondary, borderRadius: tokens.radiusMd, width: 200 }}>
+            <Text size="sm" weight="semibold">Title</Text>
+            <Text size="xs" color="secondary">Subtitle text here</Text>
+            <Button variant="primary" size="sm">Action</Button>
+          </StackAtom>
+        </Row>
+        <Row label="Gap sizes" tokens={tokens}>
+          {(['1', '3', '6'] as const).map(g => (
+            <StackAtom key={g} gap={g} style={{ padding: tokens.space3, background: tokens.surfaceSecondary, borderRadius: tokens.radiusMd }}>
+              <Text size="xs" color="secondary">gap="{g}"</Text>
+              <Badge>A</Badge>
+              <Badge>B</Badge>
+              <Badge>C</Badge>
+            </StackAtom>
+          ))}
+        </Row>
+        <Row label="Centered content" tokens={tokens}>
+          <StackAtom gap="3" align="center" justify="center" style={{ minHeight: 120, padding: tokens.space4, background: tokens.surfaceSecondary, borderRadius: tokens.radiusMd, width: 200 }}>
+            <Spinner size="sm" />
+            <Text size="sm" color="secondary">Loading...</Text>
+          </StackAtom>
+        </Row>
+      </Section>
+
+      {/* Row */}
+      <Section title="Row" tokens={tokens} hidden={!showSection('Row')}>
+        <Row label="Horizontal layout" tokens={tokens}>
+          <RowAtom gap="3" align="center">
+            <Text size="sm">Push notifications</Text>
+            <Toggle checked={toggled} onChange={setToggled} />
+          </RowAtom>
+        </Row>
+        <Row label="justify=between" tokens={tokens}>
+          <RowAtom gap="3" justify="between" style={{ width: '100%', maxWidth: 400 }}>
+            <Text as="span" size="sm" weight="semibold">Dashboard</Text>
+            <RowAtom gap="2">
+              <Button variant="outline" size="sm">Export</Button>
+              <Button variant="primary" size="sm">New</Button>
+            </RowAtom>
+          </RowAtom>
+        </Row>
+        <Row label="Wrap" tokens={tokens}>
+          <RowAtom gap="2" wrap style={{ maxWidth: 260 }}>
+            {['React', 'TypeScript', 'Design', 'Systems', 'Tokens', 'Layout'].map(t => (
+              <Badge key={t}>{t}</Badge>
+            ))}
+          </RowAtom>
+        </Row>
+        <Row label="Stack + Row composition" tokens={tokens}>
+          <Card variant="outline" padding="md" style={{ width: 280 }}>
+            <StackAtom gap="4">
+              <RowAtom gap="3" align="center">
+                <Avatar alt="Jane Doe" size="md" />
+                <StackAtom gap="1">
+                  <Text size="sm" weight="semibold">Jane Doe</Text>
+                  <Text size="xs" color="secondary">Software Engineer</Text>
+                </StackAtom>
+              </RowAtom>
+              <Divider />
+              <RowAtom gap="2" justify="end">
+                <Button variant="outline" size="sm">Message</Button>
+                <Button variant="primary" size="sm">Follow</Button>
+              </RowAtom>
+            </StackAtom>
+          </Card>
+        </Row>
+      </Section>
       </div>
       ) : tab === 'tokens' ? (
         <TokenPreview />
@@ -2192,16 +2266,16 @@ function Section({ title, tokens, children, hidden }: { title: string; tokens: R
   return (
     <Card variant="outline" padding="lg" style={{ marginBottom: tokens.space6 }}>
       <Text as="h2" size="lg" weight="semibold" style={{ marginBottom: tokens.space5, marginTop: 0 }}>{title}</Text>
-      <div style={{ display: 'flex', flexDirection: 'column', gap: tokens.space4 }}>{children}</div>
+      <StackAtom gap="4">{children}</StackAtom>
     </Card>
   );
 }
 
 function Row({ label, tokens, children }: { label: string; tokens: ReturnType<typeof useLucent>['tokens']; children: React.ReactNode }) {
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: tokens.space2 }}>
+    <StackAtom gap="2">
       <span style={{ fontSize: tokens.fontSizeXs, color: tokens.textSecondary, fontFamily: tokens.fontFamilyMono, letterSpacing: tokens.letterSpacingWide, textTransform: 'uppercase' }}>{label}</span>
-      <div style={{ display: 'flex', alignItems: 'center', gap: tokens.space3, flexWrap: 'wrap' }}>{children}</div>
-    </div>
+      <RowAtom gap="3" wrap>{children}</RowAtom>
+    </StackAtom>
   );
 }

--- a/src/components/atoms/Row/Row.manifest.ts
+++ b/src/components/atoms/Row/Row.manifest.ts
@@ -1,0 +1,112 @@
+import type { ComponentManifest } from '../../../manifest/types.js';
+
+export const COMPONENT_MANIFEST: ComponentManifest = {
+  id: 'row',
+  name: 'Row',
+  tier: 'atom',
+  domain: 'neutral',
+  specVersion: '0.1',
+
+  description: 'Horizontal flex layout primitive that spaces children using design-system gap tokens.',
+
+  designIntent:
+    'Row is the primary horizontal layout container. Use it any time you need to arrange elements ' +
+    'side by side — button groups, label-value pairs, icon + text combos, toolbar actions. ' +
+    'Default align is "center" (vertical centering), which is the most common horizontal layout need. ' +
+    'Use justify="between" for space-between patterns like a header with title on the left and actions ' +
+    'on the right. Set wrap=true when items should flow to the next line on narrow screens. ' +
+    'Row does not add padding — wrap it in a Card or apply padding on a parent container instead. ' +
+    'For vertical arrangement, use Stack instead.',
+
+  props: [
+    {
+      name: 'gap',
+      type: 'enum',
+      required: false,
+      default: '3',
+      description: 'Spacing between children. Maps to --lucent-space-{n} tokens.',
+      enumValues: ['0', '1', '2', '3', '4', '5', '6', '8', '10', '12', '16', '20', '24'],
+    },
+    {
+      name: 'align',
+      type: 'enum',
+      required: false,
+      default: 'center',
+      description: 'Cross-axis alignment (alignItems). "center" vertically centers items, which is the most common need.',
+      enumValues: ['start', 'center', 'end', 'stretch', 'baseline'],
+    },
+    {
+      name: 'justify',
+      type: 'enum',
+      required: false,
+      default: 'start',
+      description: 'Main-axis distribution (justifyContent). Use "between" for label/action pairs.',
+      enumValues: ['start', 'center', 'end', 'between', 'around'],
+    },
+    {
+      name: 'as',
+      type: 'enum',
+      required: false,
+      default: 'div',
+      description: 'HTML element to render. Use semantic elements when appropriate (nav for navigation, form for forms).',
+      enumValues: ['div', 'section', 'nav', 'form', 'fieldset', 'ul', 'ol'],
+    },
+    {
+      name: 'wrap',
+      type: 'boolean',
+      required: false,
+      default: 'false',
+      description: 'Whether children should wrap to the next line when they exceed the container width.',
+    },
+    {
+      name: 'children',
+      type: 'ReactNode',
+      required: true,
+      description: 'The elements to arrange horizontally.',
+    },
+    {
+      name: 'style',
+      type: 'object',
+      required: false,
+      description: 'Inline style overrides. Applied after computed layout styles.',
+    },
+    {
+      name: 'className',
+      type: 'string',
+      required: false,
+      description: 'CSS class name passthrough.',
+    },
+  ],
+
+  usageExamples: [
+    {
+      title: 'Settings toggle',
+      code: `<Row gap="3" justify="between">\n  <Text size="sm">Push notifications</Text>\n  <Toggle />\n</Row>`,
+    },
+    {
+      title: 'Button group',
+      code: `<Row gap="2">\n  <Button variant="primary">Save</Button>\n  <Button variant="outline">Cancel</Button>\n</Row>`,
+    },
+    {
+      title: 'Stats row',
+      code: `<Row gap="6" wrap>\n  <Stack gap="1">\n    <Text size="2xl" weight="bold">1,234</Text>\n    <Text size="xs" color="secondary">Users</Text>\n  </Stack>\n  <Stack gap="1">\n    <Text size="2xl" weight="bold">56.7%</Text>\n    <Text size="xs" color="secondary">Conversion</Text>\n  </Stack>\n</Row>`,
+    },
+    {
+      title: 'Icon + text',
+      code: `<Row gap="2" align="center">\n  <Icon name="check" size={16} />\n  <Text size="sm" color="success">Verified</Text>\n</Row>`,
+    },
+    {
+      title: 'Header with actions',
+      code: `<Row justify="between">\n  <Text as="h2" size="xl" weight="semibold">Dashboard</Text>\n  <Row gap="2">\n    <Button variant="outline" size="sm">Export</Button>\n    <Button variant="primary" size="sm">New report</Button>\n  </Row>\n</Row>`,
+    },
+  ],
+
+  compositionGraph: [],
+
+  accessibility: {
+    notes:
+      'Row renders a <div> by default, which has no implicit ARIA role. Use the `as` prop to render ' +
+      'semantic elements (nav, section) when the content has a specific structural purpose. ' +
+      'For toolbar patterns, consider adding role="toolbar" via the role prop.',
+  },
+};

--- a/src/components/atoms/Row/Row.tsx
+++ b/src/components/atoms/Row/Row.tsx
@@ -1,0 +1,65 @@
+import type { CSSProperties, ReactNode } from 'react';
+
+export type RowAs = 'div' | 'section' | 'nav' | 'form' | 'fieldset' | 'ul' | 'ol';
+
+export type RowGap =
+  | '0' | '1' | '2' | '3' | '4' | '5' | '6'
+  | '8' | '10' | '12' | '16' | '20' | '24';
+
+export type RowAlign = 'start' | 'center' | 'end' | 'stretch' | 'baseline';
+export type RowJustify = 'start' | 'center' | 'end' | 'between' | 'around';
+
+export interface RowProps {
+  gap?: RowGap;
+  align?: RowAlign;
+  justify?: RowJustify;
+  as?: RowAs;
+  wrap?: boolean;
+  children: ReactNode;
+  style?: CSSProperties;
+  className?: string;
+  id?: string;
+  role?: string;
+  'aria-label'?: string;
+  'aria-labelledby'?: string;
+}
+
+const alignMap: Record<RowAlign, string> = {
+  start:    'flex-start',
+  center:   'center',
+  end:      'flex-end',
+  stretch:  'stretch',
+  baseline: 'baseline',
+};
+
+const justifyMap: Record<RowJustify, string> = {
+  start:   'flex-start',
+  center:  'center',
+  end:     'flex-end',
+  between: 'space-between',
+  around:  'space-around',
+};
+
+export function Row({
+  gap = '3',
+  align = 'center',
+  justify = 'start',
+  as = 'div',
+  wrap = false,
+  children,
+  style,
+  ...rest
+}: RowProps) {
+  const computedStyle: CSSProperties = {
+    display: 'flex',
+    flexDirection: 'row',
+    gap: `var(--lucent-space-${gap})`,
+    alignItems: alignMap[align],
+    justifyContent: justifyMap[justify],
+    ...(wrap && { flexWrap: 'wrap' }),
+    ...style,
+  };
+
+  const Tag = as as React.ElementType;
+  return <Tag style={computedStyle} {...rest}>{children}</Tag>;
+}

--- a/src/components/atoms/Row/index.ts
+++ b/src/components/atoms/Row/index.ts
@@ -1,0 +1,3 @@
+export { Row } from './Row.js';
+export type { RowProps, RowAs, RowGap, RowAlign, RowJustify } from './Row.js';
+export { COMPONENT_MANIFEST as RowManifest } from './Row.manifest.js';

--- a/src/components/atoms/Stack/Stack.manifest.ts
+++ b/src/components/atoms/Stack/Stack.manifest.ts
@@ -1,0 +1,111 @@
+import type { ComponentManifest } from '../../../manifest/types.js';
+
+export const COMPONENT_MANIFEST: ComponentManifest = {
+  id: 'stack',
+  name: 'Stack',
+  tier: 'atom',
+  domain: 'neutral',
+  specVersion: '0.1',
+
+  description: 'Vertical flex layout primitive that spaces children using design-system gap tokens.',
+
+  designIntent:
+    'Stack is the primary vertical layout container. Use it any time you need to arrange elements ' +
+    'in a column with consistent spacing — form fields, card content, page sections, sidebar navigation. ' +
+    'The gap prop maps to spacing tokens (--lucent-space-*), enforcing consistent vertical rhythm ' +
+    'without manual margin management. Prefer Stack over raw inline flex styles for maintainability ' +
+    'and readability. Use Row (the horizontal counterpart) when items should flow left-to-right. ' +
+    'Stack does not add padding — wrap it in a Card or apply padding on a parent container instead.',
+
+  props: [
+    {
+      name: 'gap',
+      type: 'enum',
+      required: false,
+      default: '4',
+      description: 'Spacing between children. Maps to --lucent-space-{n} tokens.',
+      enumValues: ['0', '1', '2', '3', '4', '5', '6', '8', '10', '12', '16', '20', '24'],
+    },
+    {
+      name: 'align',
+      type: 'enum',
+      required: false,
+      default: 'stretch',
+      description: 'Cross-axis alignment (alignItems). "stretch" fills the container width.',
+      enumValues: ['start', 'center', 'end', 'stretch', 'baseline'],
+    },
+    {
+      name: 'justify',
+      type: 'enum',
+      required: false,
+      default: 'start',
+      description: 'Main-axis distribution (justifyContent).',
+      enumValues: ['start', 'center', 'end', 'between', 'around'],
+    },
+    {
+      name: 'as',
+      type: 'enum',
+      required: false,
+      default: 'div',
+      description: 'HTML element to render. Use semantic elements when appropriate (nav for navigation, form for forms).',
+      enumValues: ['div', 'section', 'nav', 'form', 'fieldset', 'ul', 'ol'],
+    },
+    {
+      name: 'wrap',
+      type: 'boolean',
+      required: false,
+      default: 'false',
+      description: 'Whether children should wrap to the next line when they exceed the container width.',
+    },
+    {
+      name: 'children',
+      type: 'ReactNode',
+      required: true,
+      description: 'The elements to arrange vertically.',
+    },
+    {
+      name: 'style',
+      type: 'object',
+      required: false,
+      description: 'Inline style overrides. Applied after computed layout styles.',
+    },
+    {
+      name: 'className',
+      type: 'string',
+      required: false,
+      description: 'CSS class name passthrough.',
+    },
+  ],
+
+  usageExamples: [
+    {
+      title: 'Form layout',
+      code: `<Stack gap="4">\n  <FormField label="Name"><Input /></FormField>\n  <FormField label="Email"><Input type="email" /></FormField>\n  <Button variant="primary">Submit</Button>\n</Stack>`,
+    },
+    {
+      title: 'Card content',
+      code: `<Card padding="lg">\n  <Stack gap="3">\n    <Text as="h3" size="lg" weight="semibold">Title</Text>\n    <Text size="sm" color="secondary">Description goes here.</Text>\n    <Button variant="outline" size="sm">Learn more</Button>\n  </Stack>\n</Card>`,
+    },
+    {
+      title: 'Tight spacing',
+      code: `<Stack gap="1">\n  <Text size="sm" weight="medium">Label</Text>\n  <Text size="xs" color="secondary">Helper text</Text>\n</Stack>`,
+    },
+    {
+      title: 'Centered content',
+      code: `<Stack gap="4" align="center" justify="center" style={{ minHeight: 200 }}>\n  <Spinner />\n  <Text color="secondary">Loading...</Text>\n</Stack>`,
+    },
+    {
+      title: 'Semantic nav',
+      code: `<Stack as="nav" gap="1">\n  <NavLink href="/home">Home</NavLink>\n  <NavLink href="/settings">Settings</NavLink>\n</Stack>`,
+    },
+  ],
+
+  compositionGraph: [],
+
+  accessibility: {
+    notes:
+      'Stack renders a <div> by default, which has no implicit ARIA role. Use the `as` prop to render ' +
+      'semantic elements (nav, section, form) when the content has a specific structural purpose. ' +
+      'Add aria-label or aria-labelledby when using landmark elements.',
+  },
+};

--- a/src/components/atoms/Stack/Stack.tsx
+++ b/src/components/atoms/Stack/Stack.tsx
@@ -1,0 +1,65 @@
+import type { CSSProperties, ReactNode } from 'react';
+
+export type StackAs = 'div' | 'section' | 'nav' | 'form' | 'fieldset' | 'ul' | 'ol';
+
+export type StackGap =
+  | '0' | '1' | '2' | '3' | '4' | '5' | '6'
+  | '8' | '10' | '12' | '16' | '20' | '24';
+
+export type StackAlign = 'start' | 'center' | 'end' | 'stretch' | 'baseline';
+export type StackJustify = 'start' | 'center' | 'end' | 'between' | 'around';
+
+export interface StackProps {
+  gap?: StackGap;
+  align?: StackAlign;
+  justify?: StackJustify;
+  as?: StackAs;
+  wrap?: boolean;
+  children: ReactNode;
+  style?: CSSProperties;
+  className?: string;
+  id?: string;
+  role?: string;
+  'aria-label'?: string;
+  'aria-labelledby'?: string;
+}
+
+const alignMap: Record<StackAlign, string> = {
+  start:    'flex-start',
+  center:   'center',
+  end:      'flex-end',
+  stretch:  'stretch',
+  baseline: 'baseline',
+};
+
+const justifyMap: Record<StackJustify, string> = {
+  start:   'flex-start',
+  center:  'center',
+  end:     'flex-end',
+  between: 'space-between',
+  around:  'space-around',
+};
+
+export function Stack({
+  gap = '4',
+  align = 'stretch',
+  justify = 'start',
+  as = 'div',
+  wrap = false,
+  children,
+  style,
+  ...rest
+}: StackProps) {
+  const computedStyle: CSSProperties = {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: `var(--lucent-space-${gap})`,
+    alignItems: alignMap[align],
+    justifyContent: justifyMap[justify],
+    ...(wrap && { flexWrap: 'wrap' }),
+    ...style,
+  };
+
+  const Tag = as as React.ElementType;
+  return <Tag style={computedStyle} {...rest}>{children}</Tag>;
+}

--- a/src/components/atoms/Stack/index.ts
+++ b/src/components/atoms/Stack/index.ts
@@ -1,0 +1,3 @@
+export { Stack } from './Stack.js';
+export type { StackProps, StackAs, StackGap, StackAlign, StackJustify } from './Stack.js';
+export { COMPONENT_MANIFEST as StackManifest } from './Stack.manifest.js';

--- a/src/components/atoms/index.ts
+++ b/src/components/atoms/index.ts
@@ -21,3 +21,5 @@ export * from './Table/index.js';
 export * from './ColorPicker/index.js';
 export * from './ColorSwatch/index.js';
 export * from './SegmentedControl/index.js';
+export * from './Stack/index.js';
+export * from './Row/index.js';


### PR DESCRIPTION
## Summary
- **Stack** — vertical flex container with token-based `gap`, polymorphic `as`, `align`, `justify`, and `wrap` props
- **Row** — horizontal flex container with the same API, defaults tuned for horizontal layout (`align="center"`, `gap="3"`)
- Full manifests with `designIntent` and usage examples for both components
- Dev preview sections (Stack and Row) with demos: gap sizes, centered content, justify-between, wrap, and a composed profile card
- Refactored `Section` and `Row` dev helpers to use the new primitives internally

Closes #92

## Test plan
- [x] TypeScript builds clean (`tsc --noEmit`)
- [x] All tests pass (1 pre-existing failure in `dist-server/` unrelated)
- [ ] Visual check: filter to "Stack" and "Row" in dev preview
- [ ] Toggle density presets (compact/spacious) and verify gaps scale
- [ ] Toggle light/dark theme and verify no visual issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)