### PR TITLE
feat: add Progress bar atom with threshold auto-variant

### DIFF
--- a/dev/ComponentPreview.tsx
+++ b/dev/ComponentPreview.tsx
@@ -55,6 +55,7 @@ import { ColorSwatch } from '../src/components/atoms/ColorSwatch/index.js';
 import { SegmentedControl } from '../src/components/atoms/SegmentedControl/index.js';
 import { Stack as StackAtom } from '../src/components/atoms/Stack/index.js';
 import { Row as RowAtom } from '../src/components/atoms/Row/index.js';
+import { Progress } from '../src/components/atoms/Progress/index.js';
 import type { LucentTokens, Theme, ThemeAnchors, UploadFile } from '../src/index.js';
 
 // ─── Palette map ────────────────────────────────────────────────────────────
@@ -162,7 +163,7 @@ const SHADOW_OPTIONS: ShadowName[] = ['flat', 'subtle', 'elevated'];
 
 type DensityPreset = 'compact' | 'default' | 'comfortable';
 type FontScalePreset = 'small' | 'default' | 'large';
-const DENSITY_PERCENT: Record<DensityPreset, number> = { compact: 85, default: 100, comfortable: 115 };
+const DENSITY_PERCENT: Record<DensityPreset, number> = { compact: 65, default: 100, comfortable: 140 };
 const FONT_SCALE_PERCENT: Record<FontScalePreset, number> = { small: 90, default: 100, large: 110 };
 const DENSITY_OPTIONS: { value: DensityPreset; label: string }[] = [
   { value: 'compact', label: 'Compact' },
@@ -402,7 +403,7 @@ function Inner({
     'Tooltip', 'Icon', 'Button', 'Avatar', 'Spinner', 'Divider',
     'Breadcrumb', 'Tabs', 'Collapsible', 'NavLink', 'PageLayout', 'DataTable',
     'CommandPalette', 'MultiSelect', 'DatePicker', 'DateRangePicker', 'FileUpload', 'Timeline', 'Menu', 'Toast',
-    'Stack', 'Row',
+    'Stack', 'Row', 'Progress',
   ];
 
   const filterLower = componentFilter.toLowerCase();
@@ -1265,6 +1266,44 @@ function Inner({
         <Row label="Disabled" tokens={tokens}>
           <div style={{ width: 280 }}>
             <Slider label="Locked" disabled defaultValue={40} showValue />
+          </div>
+        </Row>
+      </Section>
+
+      {/* Progress */}
+      <Section title="Progress" tokens={tokens} hidden={!showSection('Progress')}>
+        <Row label="Basic" tokens={tokens}>
+          <div style={{ width: 320, display: 'flex', flexDirection: 'column', gap: 'var(--lucent-space-4)' }}>
+            <Progress value={60} label />
+            <Progress value={30} variant="success" label />
+            <Progress value={75} variant="warning" label />
+            <Progress value={90} variant="danger" label />
+          </div>
+        </Row>
+        <Row label="Sizes" tokens={tokens}>
+          <div style={{ width: 320, display: 'flex', flexDirection: 'column', gap: 'var(--lucent-space-4)' }}>
+            <Progress size="sm" value={50} label />
+            <Progress size="md" value={50} label />
+            <Progress size="lg" value={50} label />
+          </div>
+        </Row>
+        <Row label="Thresholds (ascending)" tokens={tokens}>
+          <div style={{ width: 320, display: 'flex', flexDirection: 'column', gap: 'var(--lucent-space-4)' }}>
+            <Progress value={40} warnAt={60} dangerAt={85} label />
+            <Progress value={72} warnAt={60} dangerAt={85} label />
+            <Progress value={92} warnAt={60} dangerAt={85} label />
+          </div>
+        </Row>
+        <Row label="Thresholds (descending)" tokens={tokens}>
+          <div style={{ width: 320, display: 'flex', flexDirection: 'column', gap: 'var(--lucent-space-4)' }}>
+            <Progress value={80} warnAt={30} dangerAt={10} label />
+            <Progress value={22} warnAt={30} dangerAt={10} label />
+            <Progress value={5} warnAt={30} dangerAt={10} label />
+          </div>
+        </Row>
+        <Row label="Custom label" tokens={tokens}>
+          <div style={{ width: 320 }}>
+            <Progress value={3} max={5} label={<span>3 of 5 tasks</span>} />
           </div>
         </Row>
       </Section>

--- a/dev/SelectPlayground.tsx
+++ b/dev/SelectPlayground.tsx
@@ -15,6 +15,8 @@ import { DatePicker } from '../src/components/molecules/DatePicker/index.js';
 import { DateRangePicker } from '../src/components/molecules/DateRangePicker/index.js';
 import { Text } from '../src/components/atoms/Text/index.js';
 import { SegmentedControl } from '../src/components/atoms/SegmentedControl/index.js';
+import { Progress } from '../src/components/atoms/Progress/index.js';
+import { Slider } from '../src/components/atoms/Slider/index.js';
 import { Menu, MenuItem, MenuSeparator } from '../src/components/molecules/Menu/index.js';
 
 /* ------------------------------------------------------------------ */
@@ -336,6 +338,47 @@ const registry: Record<string, {
           { value: 'beta', label: 'Beta' },
           { value: 'gamma', label: 'Gamma' },
         ]}
+      />
+    ),
+  },
+
+  Slider: {
+    props: {
+      size:      { type: 'select', options: ['sm', 'md', 'lg'], default: 'md' },
+      label:     { type: 'text', default: 'Volume' },
+      showValue: { type: 'boolean', default: true },
+      disabled:  { type: 'boolean', default: false },
+    },
+    render: (v) => (
+      <Slider
+        size={v.size as 'sm' | 'md' | 'lg'}
+        {...(v.label ? { label: v.label as string } : {})}
+        showValue={v.showValue as boolean}
+        disabled={v.disabled as boolean}
+        defaultValue={40}
+      />
+    ),
+  },
+
+  Progress: {
+    props: {
+      size:     { type: 'select', options: ['sm', 'md', 'lg'], default: 'md' },
+      variant:  { type: 'select', options: ['accent', 'success', 'warning', 'danger'], default: 'accent' },
+      value:    { type: 'text', default: '65' },
+      max:      { type: 'text', default: '100' },
+      warnAt:   { type: 'text', default: '' },
+      dangerAt: { type: 'text', default: '' },
+      label:    { type: 'boolean', default: true },
+    },
+    render: (v) => (
+      <Progress
+        size={v.size as 'sm' | 'md' | 'lg'}
+        variant={v.variant as 'accent' | 'success' | 'warning' | 'danger'}
+        value={Number(v.value) || 0}
+        max={Number(v.max) || 100}
+        {...(v.warnAt && String(v.warnAt).trim() ? { warnAt: Number(v.warnAt) } : {})}
+        {...(v.dangerAt && String(v.dangerAt).trim() ? { dangerAt: Number(v.dangerAt) } : {})}
+        label={v.label as boolean}
       />
     ),
   },

--- a/src/components/atoms/Progress/Progress.manifest.ts
+++ b/src/components/atoms/Progress/Progress.manifest.ts
@@ -1,0 +1,36 @@
+import type { ComponentManifest } from '../../../manifest/types.js';
+
+export const COMPONENT_MANIFEST: ComponentManifest = {
+  id: 'progress',
+  name: 'Progress',
+  tier: 'atom',
+  domain: 'neutral',
+  specVersion: '0.1',
+  description: 'A horizontal bar indicating completion, progress, or resource usage.',
+  designIntent:
+    'Use Progress to visualise a bounded numeric value — task completion, disk usage, health bars, etc. ' +
+    'Set warnAt/dangerAt thresholds for automatic colour shifts instead of hardcoding variants. ' +
+    'Ascending thresholds (warnAt < dangerAt) suit "high is bad" metrics like CPU; ' +
+    'descending thresholds (warnAt > dangerAt) suit "low is bad" metrics like battery.',
+  props: [
+    { name: 'value', type: 'number', required: true, description: 'Current progress value.' },
+    { name: 'max', type: 'number', required: false, default: '100', description: 'Maximum value.' },
+    { name: 'variant', type: 'enum', required: false, default: 'accent', description: 'Colour variant. Overridden when thresholds are set.', enumValues: ['accent', 'success', 'warning', 'danger'] },
+    { name: 'size', type: 'enum', required: false, default: 'md', description: 'Bar height.', enumValues: ['sm', 'md', 'lg'] },
+    { name: 'warnAt', type: 'number', required: false, description: 'Value at which variant auto-switches to warning.' },
+    { name: 'dangerAt', type: 'number', required: false, description: 'Value at which variant auto-switches to danger.' },
+    { name: 'label', type: 'union', required: false, description: 'true shows percentage; ReactNode shows custom label.' },
+  ],
+  usageExamples: [
+    { title: 'Basic', code: `<Progress value={60} />` },
+    { title: 'With label', code: `<Progress value={42} label />` },
+    { title: 'Thresholds', code: `<Progress value={85} warnAt={70} dangerAt={90} label />` },
+    { title: 'Danger variant', code: `<Progress value={95} variant="danger" size="lg" label />` },
+  ],
+  compositionGraph: [],
+  accessibility: {
+    role: 'progressbar',
+    ariaAttributes: ['aria-valuenow', 'aria-valuemin', 'aria-valuemax'],
+    notes: 'Uses native progressbar role. Add aria-label on the wrapping element for screen-reader context.',
+  },
+};

--- a/src/components/atoms/Progress/Progress.tsx
+++ b/src/components/atoms/Progress/Progress.tsx
@@ -1,0 +1,142 @@
+import type { CSSProperties, ReactNode } from 'react';
+
+export type ProgressVariant = 'accent' | 'success' | 'warning' | 'danger';
+export type ProgressSize = 'sm' | 'md' | 'lg';
+
+export interface ProgressProps {
+  value: number;
+  max?: number;
+  variant?: ProgressVariant;
+  size?: ProgressSize;
+  warnAt?: number;
+  dangerAt?: number;
+  label?: boolean | ReactNode;
+  style?: CSSProperties;
+}
+
+const sizeStyles: Record<ProgressSize, { height: number; radius: string }> = {
+  sm: { height: 4, radius: 'var(--lucent-radius-sm)' },
+  md: { height: 8, radius: 'var(--lucent-radius-md)' },
+  lg: { height: 12, radius: 'var(--lucent-radius-md)' },
+};
+
+const variantColors: Record<ProgressVariant, string> = {
+  accent: 'var(--lucent-accent-default)',
+  success: 'var(--lucent-success-default)',
+  warning: 'var(--lucent-warning-default)',
+  danger: 'var(--lucent-danger-default)',
+};
+
+function resolveVariant(
+  value: number,
+  max: number,
+  variant: ProgressVariant | undefined,
+  warnAt: number | undefined,
+  dangerAt: number | undefined,
+): ProgressVariant {
+  if (warnAt !== undefined && dangerAt !== undefined) {
+    if (warnAt <= dangerAt) {
+      // Ascending: e.g. CPU usage — high is bad
+      if (value >= dangerAt) return 'danger';
+      if (value >= warnAt) return 'warning';
+      return 'success';
+    }
+    // Descending: e.g. battery — low is bad
+    if (value <= dangerAt) return 'danger';
+    if (value <= warnAt) return 'warning';
+    return 'success';
+  }
+
+  if (warnAt !== undefined) {
+    const ascending = warnAt <= max / 2 ? false : true;
+    if (ascending) {
+      if (value >= warnAt) return 'warning';
+      return variant ?? 'accent';
+    }
+    if (value <= warnAt) return 'warning';
+    return variant ?? 'accent';
+  }
+
+  if (dangerAt !== undefined) {
+    const ascending = dangerAt <= max / 2 ? false : true;
+    if (ascending) {
+      if (value >= dangerAt) return 'danger';
+      return variant ?? 'accent';
+    }
+    if (value <= dangerAt) return 'danger';
+    return variant ?? 'accent';
+  }
+
+  return variant ?? 'accent';
+}
+
+export function Progress({
+  value,
+  max = 100,
+  variant,
+  size = 'md',
+  warnAt,
+  dangerAt,
+  label,
+  style,
+}: ProgressProps) {
+  const clamped = Math.max(0, Math.min(value, max));
+  const pct = max > 0 ? (clamped / max) * 100 : 0;
+  const resolved = resolveVariant(clamped, max, variant, warnAt, dangerAt);
+  const s = sizeStyles[size];
+  const fill = variantColors[resolved];
+
+  const labelContent =
+    label === true
+      ? `${Math.round(pct)}%`
+      : label || null;
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 'var(--lucent-space-3)',
+        fontFamily: 'var(--lucent-font-family-base)',
+        ...style,
+      }}
+    >
+      <div
+        role="progressbar"
+        aria-valuenow={clamped}
+        aria-valuemin={0}
+        aria-valuemax={max}
+        style={{
+          flex: 1,
+          height: s.height,
+          borderRadius: s.radius,
+          background: 'var(--lucent-surface-secondary)',
+          overflow: 'hidden',
+        }}
+      >
+        <div
+          style={{
+            width: `${pct}%`,
+            height: '100%',
+            borderRadius: s.radius,
+            background: fill,
+            transition: `width var(--lucent-duration-base) var(--lucent-easing-default), background var(--lucent-duration-base) var(--lucent-easing-default)`,
+          }}
+        />
+      </div>
+      {labelContent != null && (
+        <span
+          style={{
+            fontSize: 'var(--lucent-font-size-sm)',
+            fontWeight: 'var(--lucent-font-weight-medium)',
+            color: 'var(--lucent-text-secondary)',
+            whiteSpace: 'nowrap',
+            flexShrink: 0,
+          }}
+        >
+          {labelContent}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/components/atoms/Progress/index.ts
+++ b/src/components/atoms/Progress/index.ts
@@ -1,0 +1,3 @@
+export { Progress } from './Progress.js';
+export type { ProgressProps, ProgressVariant, ProgressSize } from './Progress.js';
+export { COMPONENT_MANIFEST as ProgressManifest } from './Progress.manifest.js';

--- a/src/components/atoms/index.ts
+++ b/src/components/atoms/index.ts
@@ -23,3 +23,4 @@ export * from './ColorSwatch/index.js';
 export * from './SegmentedControl/index.js';
 export * from './Stack/index.js';
 export * from './Row/index.js';
+export * from './Progress/index.js';


### PR DESCRIPTION
## Summary
- New `Progress` atom with `value`/`max`, `size` (sm/md/lg), `variant` (accent/success/warning/danger), and `warnAt`/`dangerAt` threshold props that auto-switch color based on value direction
- Added Progress and Slider to the component playground for side-by-side comparison
- Widened density preview multipliers (65%/140%) so compact vs comfortable is actually visible

Closes #84

## Test plan
- [ ] Verify Progress renders with all variants (accent, success, warning, danger)
- [ ] Verify all sizes (sm/md/lg) render correct bar heights
- [ ] Test ascending thresholds (warnAt=60, dangerAt=85): green below 60, yellow 60–84, red 85+
- [ ] Test descending thresholds (warnAt=30, dangerAt=10): green above 30, yellow 10–30, red below 10
- [ ] Verify `label={true}` shows percentage, custom ReactNode label works
- [ ] Check smooth transition on value/variant changes
- [ ] Confirm `role="progressbar"` and aria attributes in DOM
- [ ] Test Progress and Slider in playground with prop knobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)