### PR TITLE
feat: add SplitButton and ButtonGroup atoms (#90)

### DIFF
--- a/dev/ComponentPreview.tsx
+++ b/dev/ComponentPreview.tsx
@@ -56,6 +56,8 @@ import { SegmentedControl } from '../src/components/atoms/SegmentedControl/index
 import { Stack as StackAtom } from '../src/components/atoms/Stack/index.js';
 import { Row as RowAtom } from '../src/components/atoms/Row/index.js';
 import { Progress } from '../src/components/atoms/Progress/index.js';
+import { SplitButton } from '../src/components/atoms/SplitButton/index.js';
+import { ButtonGroup } from '../src/components/atoms/ButtonGroup/index.js';
 import type { LucentTokens, Theme, ThemeAnchors, UploadFile } from '../src/index.js';
 
 // ─── Palette map ────────────────────────────────────────────────────────────
@@ -403,7 +405,7 @@ function Inner({
     'Tooltip', 'Icon', 'Button', 'Avatar', 'Spinner', 'Divider',
     'Breadcrumb', 'Tabs', 'Collapsible', 'NavLink', 'PageLayout', 'DataTable',
     'CommandPalette', 'MultiSelect', 'DatePicker', 'DateRangePicker', 'FileUpload', 'Timeline', 'Menu', 'Toast',
-    'Stack', 'Row', 'Progress',
+    'Stack', 'Row', 'Progress', 'SplitButton', 'ButtonGroup',
   ];
 
   const filterLower = componentFilter.toLowerCase();
@@ -1731,6 +1733,128 @@ function Inner({
         <Row label="States" tokens={tokens}>
           <Button loading>Loading</Button>
           <Button variant="primary" fullWidth>Full width</Button>
+        </Row>
+      </Section>
+
+      {/* SplitButton */}
+      <Section title="SplitButton" tokens={tokens} hidden={!showSection('SplitButton')}>
+        <StackAtom gap="2">
+          <span style={{ fontSize: tokens.fontSizeXs, color: tokens.textSecondary, fontFamily: tokens.fontFamilyMono, letterSpacing: tokens.letterSpacingWide, textTransform: 'uppercase' }}>Variants</span>
+          <RowAtom gap="5" wrap>
+            {(['primary', 'secondary', 'outline', 'ghost', 'danger', 'danger-outline', 'danger-ghost'] as const).map((v) => (
+              <SplitButton key={v} variant={v} onClick={() => alert(`${v} primary`)} menuItems={[{ label: 'Alternative A', onSelect: () => alert('A') }, { label: 'Alternative B', onSelect: () => alert('B') }]}>
+                {v.charAt(0).toUpperCase() + v.slice(1)}
+              </SplitButton>
+            ))}
+          </RowAtom>
+        </StackAtom>
+        <StackAtom gap="2">
+          <span style={{ fontSize: tokens.fontSizeXs, color: tokens.textSecondary, fontFamily: tokens.fontFamilyMono, letterSpacing: tokens.letterSpacingWide, textTransform: 'uppercase' }}>Sizes</span>
+          <RowAtom gap="5" wrap>
+            {(['2xs', 'xs', 'sm', 'md', 'lg'] as const).map((s) => (
+              <SplitButton key={s} size={s} onClick={() => {}} menuItems={[{ label: 'Option', onSelect: () => {} }]}>
+                {s}
+              </SplitButton>
+            ))}
+          </RowAtom>
+        </StackAtom>
+        <StackAtom gap="2">
+          <span style={{ fontSize: tokens.fontSizeXs, color: tokens.textSecondary, fontFamily: tokens.fontFamilyMono, letterSpacing: tokens.letterSpacingWide, textTransform: 'uppercase' }}>Bordered ghost</span>
+          <RowAtom gap="5" wrap>
+            <SplitButton variant="ghost" size="2xs" bordered onClick={() => {}} menuItems={[{ label: 'Reset layout', onSelect: () => {} }]}>Collapse all</SplitButton>
+            <SplitButton variant="ghost" size="sm" bordered onClick={() => {}} menuItems={[{ label: 'Export config', onSelect: () => {} }]}>Options</SplitButton>
+            <SplitButton variant="outline" size="sm" onClick={() => {}} menuItems={[{ label: 'Save as draft', onSelect: () => {} }, { label: 'Discard', onSelect: () => {}, danger: true }]}>Save</SplitButton>
+          </RowAtom>
+        </StackAtom>
+        <StackAtom gap="2">
+          <span style={{ fontSize: tokens.fontSizeXs, color: tokens.textSecondary, fontFamily: tokens.fontFamilyMono, letterSpacing: tokens.letterSpacingWide, textTransform: 'uppercase' }}>With icons</span>
+          <RowAtom gap="5" wrap>
+            <SplitButton leftIcon={<StarIcon />} onClick={() => {}} menuItems={[{ label: 'Save as draft', onSelect: () => {}, icon: <SmallIcon d="M19 21H5a2 2 0 01-2-2V5a2 2 0 012-2h11l5 5v11a2 2 0 01-2 2z" /> }, { label: 'Export', onSelect: () => {}, icon: <SmallIcon d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4M7 10l5 5 5-5M12 15V3" /> }]}>Save</SplitButton>
+            <SplitButton variant="outline" leftIcon={<SmallIcon d="M12 19V5M5 12l7-7 7 7" />} onClick={() => {}} menuItems={[{ label: 'Deploy to staging', onSelect: () => {}, icon: <SmallIcon d="M22 12h-4l-3 9L9 3l-3 9H2" /> }, { label: 'Rollback', onSelect: () => {}, danger: true, icon: <SmallIcon d="M1 4v6h6M23 20v-6h-6" /> }]}>Deploy</SplitButton>
+            <SplitButton variant="danger" leftIcon={<SmallIcon d="M3 6h18M8 6V4h8v2M19 6l-1 14H6L5 6" />} onClick={() => {}} menuItems={[{ label: 'Move to trash', onSelect: () => {}, icon: <SmallIcon d="M3 6h18M8 6V4h8v2M19 6l-1 14H6L5 6" /> }, { label: 'Delete forever', onSelect: () => {}, danger: true, icon: <SmallIcon d="M18 6L6 18M6 6l12 12" /> }]}>Delete</SplitButton>
+          </RowAtom>
+        </StackAtom>
+        <StackAtom gap="2">
+          <span style={{ fontSize: tokens.fontSizeXs, color: tokens.textSecondary, fontFamily: tokens.fontFamilyMono, letterSpacing: tokens.letterSpacingWide, textTransform: 'uppercase' }}>Disabled & loading</span>
+          <RowAtom gap="5" wrap>
+            <SplitButton disabled onClick={() => {}} menuItems={[{ label: 'Nope', onSelect: () => {} }]}>Disabled</SplitButton>
+            <SplitButton loading onClick={() => {}} menuItems={[{ label: 'Nope', onSelect: () => {} }]}>Loading</SplitButton>
+            <SplitButton variant="outline" disabled onClick={() => {}} menuItems={[{ label: 'Nope', onSelect: () => {} }]}>Outline disabled</SplitButton>
+          </RowAtom>
+        </StackAtom>
+      </Section>
+
+      {/* ButtonGroup */}
+      <Section title="ButtonGroup" tokens={tokens} hidden={!showSection('ButtonGroup')}>
+        <Row label="Outline toolbar" tokens={tokens}>
+          <ButtonGroup>
+            <Button variant="outline" leftIcon={<SmallIcon d="M6 4h8a4 4 0 010 8H6z" />} aria-label="Bold" />
+            <Button variant="outline" leftIcon={<SmallIcon d="M19 4h-9M14 20H5M15 4L9 20" />} aria-label="Italic" />
+            <Button variant="outline" leftIcon={<SmallIcon d="M6 3v7a6 6 0 0012 0V3M4 21h16" />} aria-label="Underline" />
+          </ButtonGroup>
+          <ButtonGroup>
+            <Button variant="outline">Left</Button>
+            <Button variant="outline">Center</Button>
+            <Button variant="outline">Right</Button>
+          </ButtonGroup>
+        </Row>
+        <Row label="Ghost toolbar" tokens={tokens}>
+          <ButtonGroup>
+            <Button variant="ghost" leftIcon={<SmallIcon d="M6 4h8a4 4 0 010 8H6z" />} aria-label="Bold" />
+            <Button variant="ghost" leftIcon={<SmallIcon d="M19 4h-9M14 20H5M15 4L9 20" />} aria-label="Italic" />
+            <Button variant="ghost" leftIcon={<SmallIcon d="M6 3v7a6 6 0 0012 0V3M4 21h16" />} aria-label="Underline" />
+          </ButtonGroup>
+          <ButtonGroup>
+            <Button variant="ghost">Left</Button>
+            <Button variant="ghost">Center</Button>
+            <Button variant="ghost">Right</Button>
+          </ButtonGroup>
+        </Row>
+        <Row label="Ghost xs" tokens={tokens}>
+          <ButtonGroup>
+            <Button variant="ghost" size="xs" leftIcon={<SmallIcon d="M6 4h8a4 4 0 010 8H6z" />} aria-label="Bold" />
+            <Button variant="ghost" size="xs" leftIcon={<SmallIcon d="M19 4h-9M14 20H5M15 4L9 20" />} aria-label="Italic" />
+            <Button variant="ghost" size="xs" leftIcon={<SmallIcon d="M6 3v7a6 6 0 0012 0V3M4 21h16" />} aria-label="Underline" />
+          </ButtonGroup>
+          <ButtonGroup>
+            <Button variant="ghost" size="xs">Left</Button>
+            <Button variant="ghost" size="xs">Center</Button>
+            <Button variant="ghost" size="xs">Right</Button>
+          </ButtonGroup>
+        </Row>
+        <Row label="Mixed variants" tokens={tokens}>
+          <ButtonGroup>
+            <Button variant="primary">Save</Button>
+            <Button variant="outline">Cancel</Button>
+          </ButtonGroup>
+          <ButtonGroup>
+            <Button variant="secondary">Edit</Button>
+            <Button variant="secondary">Duplicate</Button>
+            <Button variant="danger-outline">Delete</Button>
+          </ButtonGroup>
+        </Row>
+        <Row label="With SplitButton" tokens={tokens}>
+          <ButtonGroup>
+            <SplitButton onClick={() => {}} menuItems={[{ label: 'Deploy to staging', onSelect: () => {} }]}>Deploy</SplitButton>
+            <Button variant="outline">Logs</Button>
+          </ButtonGroup>
+        </Row>
+        <Row label="Sizes" tokens={tokens}>
+          <ButtonGroup>
+            <Button variant="outline" size="xs">A</Button>
+            <Button variant="outline" size="xs">B</Button>
+            <Button variant="outline" size="xs">C</Button>
+          </ButtonGroup>
+          <ButtonGroup>
+            <Button variant="outline" size="sm">A</Button>
+            <Button variant="outline" size="sm">B</Button>
+            <Button variant="outline" size="sm">C</Button>
+          </ButtonGroup>
+          <ButtonGroup>
+            <Button variant="outline" size="md">A</Button>
+            <Button variant="outline" size="md">B</Button>
+            <Button variant="outline" size="md">C</Button>
+          </ButtonGroup>
         </Row>
       </Section>
 

--- a/src/components/atoms/Button/Button.tsx
+++ b/src/components/atoms/Button/Button.tsx
@@ -32,7 +32,7 @@ const variantStyles: Record<ButtonVariant, CSSProperties> = {
     border: '1px solid transparent',
   },
   outline: {
-    background: 'var(--lucent-surface)',
+    background: 'transparent',
     color: 'var(--lucent-text-primary)',
     border: '1px solid var(--lucent-border-default)',
   },
@@ -47,7 +47,7 @@ const variantStyles: Record<ButtonVariant, CSSProperties> = {
     border: '1px solid var(--lucent-danger-default)',
   },
   'danger-outline': {
-    background: 'var(--lucent-surface)',
+    background: 'transparent',
     color: 'var(--lucent-danger-text)',
     border: '1px solid var(--lucent-danger-default)',
   },
@@ -59,16 +59,17 @@ const variantStyles: Record<ButtonVariant, CSSProperties> = {
 };
 
 const sizeStyles: Record<ButtonSize, CSSProperties> = {
-  '2xs': { height: '22px', padding: '0 var(--lucent-space-1)', fontSize: 'var(--lucent-font-size-xs)', borderRadius: 'var(--lucent-radius-md)' },
-  xs: { height: '26px', padding: '0 var(--lucent-space-2)', fontSize: 'var(--lucent-font-size-xs)' },
-  sm: { height: 'calc(var(--lucent-space-8) * 0.5 + 18px)', padding: '0 var(--lucent-space-3)', fontSize: 'var(--lucent-font-size-sm)' },
-  md: { height: 'calc(var(--lucent-space-10) * 0.5 + 22px)', padding: '0 var(--lucent-space-4)', fontSize: 'var(--lucent-font-size-md)' },
-  lg: { height: 'calc(var(--lucent-space-12) * 0.5 + 26px)', padding: '0 var(--lucent-space-5)', fontSize: 'var(--lucent-font-size-lg)' },
+  '2xs': { height: '22px', padding: '0 var(--lucent-space-2)', fontSize: 'var(--lucent-font-size-xs)', borderRadius: 'var(--lucent-radius-md)' },
+  xs: { height: '26px', padding: '0 var(--lucent-space-3)', fontSize: 'var(--lucent-font-size-xs)' },
+  sm: { height: 'calc(var(--lucent-space-8) * 0.5 + 18px)', padding: '0 var(--lucent-space-4)', fontSize: 'var(--lucent-font-size-sm)' },
+  md: { height: 'calc(var(--lucent-space-10) * 0.5 + 22px)', padding: '0 var(--lucent-space-5)', fontSize: 'var(--lucent-font-size-md)' },
+  lg: { height: 'calc(var(--lucent-space-12) * 0.5 + 26px)', padding: '0 var(--lucent-space-6)', fontSize: 'var(--lucent-font-size-lg)' },
 };
 
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
   ({ variant = 'primary', size = 'md', loading = false, fullWidth = false, spread = false, leftIcon, rightIcon, chevron = false, disableHoverStyles = false, bordered = true, children, disabled, style, ...rest }, ref) => {
     const isDisabled = disabled ?? loading;
+    const isIconOnly = !children && !loading && (!!leftIcon || !!rightIcon);
 
     return (
       <button
@@ -93,6 +94,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
           outline: 'none',
           margin: 0,
           ...sizeStyles[size],
+          ...(isIconOnly && { padding: 0, aspectRatio: '1' }),
           ...variantStyles[variant],
           ...style,
           ...(isDisabled && {
@@ -192,14 +194,14 @@ function removeHover(el: HTMLButtonElement, variant: ButtonVariant, bordered?: b
   } else if (variant === 'secondary') {
     el.style.background = 'var(--lucent-surface-secondary)';
   } else if (variant === 'outline') {
-    el.style.background = 'var(--lucent-surface)';
+    el.style.background = 'transparent';
   } else if (variant === 'ghost') {
     el.style.background = 'transparent';
   } else if (variant === 'danger') {
     el.style.background = 'var(--lucent-danger-default)';
     if (bordered !== false) el.style.borderColor = 'var(--lucent-danger-default)';
   } else if (variant === 'danger-outline') {
-    el.style.background = 'var(--lucent-surface)';
+    el.style.background = 'transparent';
     if (bordered !== false) el.style.borderColor = 'var(--lucent-danger-default)';
   } else if (variant === 'danger-ghost') {
     el.style.background = 'transparent';

--- a/src/components/atoms/ButtonGroup/ButtonGroup.manifest.ts
+++ b/src/components/atoms/ButtonGroup/ButtonGroup.manifest.ts
@@ -1,0 +1,46 @@
+import type { ComponentManifest } from '../../../manifest/types.js';
+
+export const COMPONENT_MANIFEST: ComponentManifest = {
+  id: 'button-group',
+  name: 'ButtonGroup',
+  tier: 'atom',
+  domain: 'neutral',
+  specVersion: '0.1',
+  description: 'A layout wrapper that visually groups multiple Button or SplitButton children into a related strip.',
+  designIntent:
+    'Use ButtonGroup for peer actions that belong together visually — toolbars, action bars, ' +
+    'toggle groups. Unlike SegmentedControl (single-select with indicator), ButtonGroup has no ' +
+    'built-in selection state; each child handles its own behaviour. ' +
+    'Items are separated by a small token-based gap with subtle inner corner radius ' +
+    'so the group reads as a unit while each button retains its own border and hover states.',
+  props: [
+    { name: 'children', type: 'ReactNode', required: true, description: 'Button or SplitButton elements to group.' },
+    { name: 'style', type: 'object', required: false, description: 'Style overrides for the wrapper div.' },
+  ],
+  usageExamples: [
+    {
+      title: 'Toolbar',
+      code: `<ButtonGroup>\n  <Button variant="outline" leftIcon={<Icon name="bold" />} />\n  <Button variant="outline" leftIcon={<Icon name="italic" />} />\n  <Button variant="outline" leftIcon={<Icon name="underline" />} />\n</ButtonGroup>`,
+    },
+    {
+      title: 'Action pair',
+      code: `<ButtonGroup>\n  <Button variant="primary">Save</Button>\n  <Button variant="outline">Cancel</Button>\n</ButtonGroup>`,
+    },
+    {
+      title: 'With SplitButton',
+      code: `<ButtonGroup>\n  <SplitButton onClick={deploy} menuItems={[{ label: 'Staging', onSelect: staging }]}>Deploy</SplitButton>\n  <Button variant="outline">Logs</Button>\n</ButtonGroup>`,
+    },
+  ],
+  compositionGraph: [
+    { componentId: 'button', componentName: 'Button', role: 'Grouped action item', required: false },
+    { componentId: 'split-button', componentName: 'SplitButton', role: 'Grouped split action item', required: false },
+  ],
+  accessibility: {
+    role: 'group',
+    ariaAttributes: [],
+    keyboardInteractions: [
+      'Tab moves focus between buttons in the group',
+    ],
+    notes: 'Uses role="group" on the wrapper. Individual button accessibility is inherited from the children.',
+  },
+};

--- a/src/components/atoms/ButtonGroup/ButtonGroup.tsx
+++ b/src/components/atoms/ButtonGroup/ButtonGroup.tsx
@@ -1,0 +1,60 @@
+import { Children, cloneElement, isValidElement, type CSSProperties, type ReactElement, type ReactNode } from 'react';
+
+export interface ButtonGroupProps {
+  /** Button or SplitButton children to group. */
+  children: ReactNode;
+  /** Style overrides for the wrapper. */
+  style?: CSSProperties;
+}
+
+const INNER_RADIUS = 'var(--lucent-radius-sm)';
+
+export function ButtonGroup({
+  children,
+  style,
+}: ButtonGroupProps) {
+  const items = Children.toArray(children).filter(isValidElement) as ReactElement[];
+  const count = items.length;
+
+  return (
+    <div
+      role="group"
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 'calc(var(--lucent-space-1) / 2)',
+        ...style,
+      }}
+    >
+      {items.map((child, i) => {
+        const isFirst = i === 0;
+        const isLast = i === count - 1;
+        const isOnly = count === 1;
+
+        if (isOnly) return child;
+
+        const childStyle: CSSProperties = (child.props as { style?: CSSProperties }).style ?? {};
+        const outerRadius = childStyle.borderRadius ?? 'var(--lucent-radius-lg)';
+
+        let borderRadius: string;
+        if (isFirst) {
+          borderRadius = `${outerRadius} ${INNER_RADIUS} ${INNER_RADIUS} ${outerRadius}`;
+        } else if (isLast) {
+          borderRadius = `${INNER_RADIUS} ${outerRadius} ${outerRadius} ${INNER_RADIUS}`;
+        } else {
+          borderRadius = INNER_RADIUS;
+        }
+
+        return cloneElement(child, {
+          key: i,
+          style: {
+            ...childStyle,
+            borderRadius,
+          },
+        } as Record<string, unknown>);
+      })}
+    </div>
+  );
+}
+
+ButtonGroup.displayName = 'ButtonGroup';

--- a/src/components/atoms/ButtonGroup/index.ts
+++ b/src/components/atoms/ButtonGroup/index.ts
@@ -1,0 +1,3 @@
+export { ButtonGroup } from './ButtonGroup.js';
+export type { ButtonGroupProps } from './ButtonGroup.js';
+export { COMPONENT_MANIFEST as ButtonGroupManifest } from './ButtonGroup.manifest.js';

--- a/src/components/atoms/SplitButton/SplitButton.manifest.ts
+++ b/src/components/atoms/SplitButton/SplitButton.manifest.ts
@@ -1,0 +1,78 @@
+import type { ComponentManifest } from '../../../manifest/types.js';
+
+export const COMPONENT_MANIFEST: ComponentManifest = {
+  id: 'split-button',
+  name: 'SplitButton',
+  tier: 'atom',
+  domain: 'neutral',
+  specVersion: '0.1',
+  description: 'A compound button pairing a primary action with a chevron dropdown for secondary actions.',
+  designIntent:
+    'Use SplitButton when there is one dominant action alongside a small set of related alternatives ' +
+    '(e.g. "Save" + "Save as draft", "Deploy" + "Deploy to staging"). ' +
+    'Each half is a fully independent button separated by a small token-based gap, with a subtle ' +
+    'inner corner radius (radius-sm) so the pair reads as a unit without sharing a border. ' +
+    'Hover lift and press ring apply independently per half. ' +
+    'Ghost variants use tighter inner padding to keep the halves visually close. ' +
+    'The chevron half opens a Menu molecule; all dropdown keyboard navigation is inherited.',
+  props: [
+    { name: 'children', type: 'ReactNode', required: true, description: 'Label content for the primary action button.' },
+    { name: 'onClick', type: 'function', required: true, description: 'Handler fired when the primary (left) half is clicked.' },
+    { name: 'menuItems', type: 'array', required: true, description: 'Array of { label, onSelect, disabled?, danger?, icon? } for the dropdown.' },
+    { name: 'variant', type: 'enum', required: false, default: 'primary', description: 'Visual variant applied to both halves.', enumValues: ['primary', 'secondary', 'outline', 'ghost', 'danger', 'danger-outline', 'danger-ghost'] },
+    { name: 'size', type: 'enum', required: false, default: 'md', description: 'Size applied to both halves.', enumValues: ['2xs', 'xs', 'sm', 'md', 'lg'] },
+    { name: 'bordered', type: 'boolean', required: false, default: 'true', description: 'If false, removes the border on both halves.' },
+    { name: 'menuPlacement', type: 'enum', required: false, default: 'bottom-end', description: 'Dropdown placement relative to the chevron trigger.', enumValues: ['top', 'top-start', 'top-end', 'bottom', 'bottom-start', 'bottom-end', 'left', 'right'] },
+    { name: 'disabled', type: 'boolean', required: false, description: 'Disables both halves.' },
+    { name: 'loading', type: 'boolean', required: false, default: 'false', description: 'Shows a spinner in the primary half and disables both.' },
+    { name: 'leftIcon', type: 'ReactNode', required: false, description: 'Icon rendered before the label in the primary half.' },
+    { name: 'style', type: 'object', required: false, description: 'Style overrides for the wrapper div.' },
+  ],
+  usageExamples: [
+    {
+      title: 'Basic',
+      code: `<SplitButton onClick={handleSave} menuItems={[{ label: 'Save as draft', onSelect: handleDraft }]}>Save</SplitButton>`,
+    },
+    {
+      title: 'Outline with leftIcon',
+      code: `<SplitButton variant="outline" leftIcon={<Icon name="deploy" />} onClick={deploy} menuItems={[{ label: 'Deploy to staging', onSelect: deployStaging }, { label: 'Rollback', onSelect: rollback, danger: true }]}>Deploy</SplitButton>`,
+    },
+    {
+      title: 'Menu items with icons',
+      code: `<SplitButton onClick={handleSave} menuItems={[{ label: 'Save as draft', onSelect: handleDraft, icon: <Icon name="file" /> }, { label: 'Export', onSelect: handleExport, icon: <Icon name="download" /> }]}>Save</SplitButton>`,
+    },
+    {
+      title: 'Small ghost bordered (issue #90 use case)',
+      code: `<SplitButton variant="ghost" size="2xs" bordered onClick={toggle} menuItems={[{ label: 'Reset layout', onSelect: reset }]}>Collapse all</SplitButton>`,
+    },
+    {
+      title: 'Danger outline with disabled item',
+      code: `<SplitButton variant="danger-outline" onClick={handleDelete} menuItems={[{ label: 'Move to trash', onSelect: trash }, { label: 'Delete forever', onSelect: nuke, danger: true }, { label: 'Archive (unavailable)', onSelect: archive, disabled: true }]}>Delete</SplitButton>`,
+    },
+    {
+      title: 'Disabled',
+      code: `<SplitButton disabled onClick={handleSave} menuItems={[{ label: 'Option', onSelect: fn }]}>Save</SplitButton>`,
+    },
+    {
+      title: 'Loading',
+      code: `<SplitButton loading onClick={handleSave} menuItems={[{ label: 'Option', onSelect: fn }]}>Saving...</SplitButton>`,
+    },
+  ],
+  compositionGraph: [
+    { componentId: 'menu', componentName: 'Menu', role: 'Dropdown container for secondary actions', required: true },
+    { componentId: 'menu-item', componentName: 'MenuItem', role: 'Individual dropdown action', required: true },
+  ],
+  accessibility: {
+    role: 'group',
+    ariaAttributes: ['aria-label', 'aria-haspopup', 'aria-expanded', 'aria-busy'],
+    keyboardInteractions: [
+      'Enter/Space on primary button fires onClick',
+      'Enter/Space/ArrowDown on chevron opens dropdown',
+      'ArrowDown/ArrowUp cycles dropdown items',
+      'Home/End jumps to first/last item',
+      'Escape closes dropdown and returns focus to chevron',
+      'Tab closes dropdown',
+    ],
+    notes: 'The wrapper uses role="group" with aria-label derived from children. The chevron button carries aria-haspopup="menu" and aria-expanded via Menu. Primary button has aria-busy when loading.',
+  },
+};

--- a/src/components/atoms/SplitButton/SplitButton.tsx
+++ b/src/components/atoms/SplitButton/SplitButton.tsx
@@ -1,0 +1,336 @@
+import { useState, type CSSProperties, type ReactNode } from 'react';
+import { Menu, MenuItem, type MenuPlacement, type MenuSize } from '../../molecules/Menu/index.js';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type SplitButtonVariant = 'primary' | 'secondary' | 'outline' | 'ghost' | 'danger' | 'danger-outline' | 'danger-ghost';
+export type SplitButtonSize = '2xs' | 'xs' | 'sm' | 'md' | 'lg';
+
+export interface SplitButtonMenuItem {
+  label: string;
+  onSelect: () => void;
+  disabled?: boolean;
+  danger?: boolean;
+  icon?: ReactNode;
+}
+
+export interface SplitButtonProps {
+  /** Primary button label. */
+  children: ReactNode;
+  /** Handler for the primary action (left half). */
+  onClick: () => void;
+  /** Items shown in the dropdown menu. */
+  menuItems: SplitButtonMenuItem[];
+  /** Visual variant applied to both halves. */
+  variant?: SplitButtonVariant;
+  /** Size applied to both halves. */
+  size?: SplitButtonSize;
+  /** If false, removes the border on both halves. */
+  bordered?: boolean;
+  /** Dropdown placement relative to the chevron trigger. */
+  menuPlacement?: MenuPlacement;
+  /** Disables both halves. */
+  disabled?: boolean;
+  /** Shows a spinner in the primary half and disables both. */
+  loading?: boolean;
+  /** Icon rendered before the label in the primary half. */
+  leftIcon?: ReactNode;
+  /** Style overrides for the wrapper. */
+  style?: CSSProperties;
+}
+
+// ─── Variant styles (mirrors Button) ─────────────────────────────────────────
+
+const variantStyles: Record<SplitButtonVariant, CSSProperties> = {
+  primary: {
+    background: 'var(--lucent-accent-default)',
+    color: 'var(--lucent-text-on-accent)',
+    border: '1px solid transparent',
+  },
+  secondary: {
+    background: 'color-mix(in srgb, var(--lucent-accent-default) 14%, var(--lucent-surface-secondary))',
+    color: 'var(--lucent-text-primary)',
+    border: '1px solid transparent',
+  },
+  outline: {
+    background: 'transparent',
+    color: 'var(--lucent-text-primary)',
+    border: '1px solid var(--lucent-border-default)',
+  },
+  ghost: {
+    background: 'transparent',
+    color: 'var(--lucent-text-primary)',
+    border: '1px solid transparent',
+  },
+  danger: {
+    background: 'var(--lucent-danger-default)',
+    color: '#ffffff',
+    border: '1px solid var(--lucent-danger-default)',
+  },
+  'danger-outline': {
+    background: 'transparent',
+    color: 'var(--lucent-danger-text)',
+    border: '1px solid var(--lucent-danger-default)',
+  },
+  'danger-ghost': {
+    background: 'transparent',
+    color: 'var(--lucent-danger-text)',
+    border: '1px solid transparent',
+  },
+};
+
+// ─── Size styles ─────────────────────────────────────────────────────────────
+
+interface SplitSizeStyle {
+  height: string;
+  paddingOuter: string;
+  paddingInner: string;
+  fontSize: string;
+  borderRadius?: string;
+}
+
+const sizeStyles: Record<SplitButtonSize, SplitSizeStyle> = {
+  '2xs': { height: '22px', paddingOuter: 'var(--lucent-space-2)', paddingInner: 'var(--lucent-space-1)', fontSize: 'var(--lucent-font-size-xs)', borderRadius: 'var(--lucent-radius-md)' },
+  xs: { height: '26px', paddingOuter: 'var(--lucent-space-3)', paddingInner: 'var(--lucent-space-1)', fontSize: 'var(--lucent-font-size-xs)' },
+  sm: { height: 'calc(var(--lucent-space-8) * 0.5 + 18px)', paddingOuter: 'var(--lucent-space-4)', paddingInner: 'var(--lucent-space-2)', fontSize: 'var(--lucent-font-size-sm)' },
+  md: { height: 'calc(var(--lucent-space-10) * 0.5 + 22px)', paddingOuter: 'var(--lucent-space-5)', paddingInner: 'var(--lucent-space-3)', fontSize: 'var(--lucent-font-size-md)' },
+  lg: { height: 'calc(var(--lucent-space-12) * 0.5 + 26px)', paddingOuter: 'var(--lucent-space-6)', paddingInner: 'var(--lucent-space-3)', fontSize: 'var(--lucent-font-size-lg)' },
+};
+
+const chevronSizePx: Record<SplitButtonSize, number> = { '2xs': 8, xs: 10, sm: 12, md: 14, lg: 16 };
+
+const chevronBtnWidth: Record<SplitButtonSize, string> = {
+  '2xs': '24px',
+  xs: '30px',
+  sm: '34px',
+  md: '36px',
+  lg: '42px',
+};
+
+const menuSizeMap: Record<SplitButtonSize, MenuSize> = {
+  '2xs': 'sm',
+  xs: 'sm',
+  sm: 'sm',
+  md: 'md',
+  lg: 'lg',
+};
+
+// ─── Hover helpers ────────────────────────────────────────────────────────────
+
+const hoverBg: Record<SplitButtonVariant, string> = {
+  primary: 'var(--lucent-accent-hover)',
+  secondary: 'color-mix(in srgb, var(--lucent-accent-default) 10%, var(--lucent-surface-secondary))',
+  outline: 'color-mix(in srgb, var(--lucent-accent-default) 10%, var(--lucent-surface))',
+  ghost: 'color-mix(in srgb, var(--lucent-accent-default) 8%, var(--lucent-surface))',
+  danger: 'var(--lucent-danger-hover)',
+  'danger-outline': 'color-mix(in srgb, var(--lucent-danger-default) 10%, var(--lucent-surface))',
+  'danger-ghost': 'color-mix(in srgb, var(--lucent-danger-default) 8%, var(--lucent-surface))',
+};
+
+const hoverShadow: Record<SplitButtonVariant, string> = {
+  primary: '0 4px 14px -2px var(--lucent-accent-subtle)',
+  secondary: '0 4px 14px -2px var(--lucent-accent-subtle)',
+  outline: '0 4px 14px -2px var(--lucent-accent-subtle)',
+  ghost: '0 4px 14px -2px var(--lucent-accent-subtle)',
+  danger: '0 4px 14px -2px var(--lucent-danger-subtle)',
+  'danger-outline': '0 4px 14px -2px var(--lucent-danger-subtle)',
+  'danger-ghost': '0 4px 14px -2px var(--lucent-danger-subtle)',
+};
+
+// ─── Hover/press appliers (per-half, like Button) ────────────────────────────
+
+function applyHover(el: HTMLButtonElement, variant: SplitButtonVariant, bordered?: boolean) {
+  el.style.transform = 'translateY(-1px)';
+  el.style.boxShadow = hoverShadow[variant];
+  el.style.background = hoverBg[variant];
+
+  if (variant === 'danger' && bordered !== false) {
+    el.style.borderColor = 'var(--lucent-danger-hover)';
+  } else if (variant === 'danger-outline' && bordered !== false) {
+    el.style.borderColor = 'var(--lucent-danger-hover)';
+  }
+}
+
+function removeHover(el: HTMLButtonElement, variant: SplitButtonVariant, bordered?: boolean) {
+  el.style.transform = '';
+  el.style.boxShadow = '';
+  el.style.background = variantStyles[variant].background as string;
+
+  if (variant === 'danger' && bordered !== false) {
+    el.style.borderColor = 'var(--lucent-danger-default)';
+  } else if (variant === 'danger-outline' && bordered !== false) {
+    el.style.borderColor = 'var(--lucent-danger-default)';
+  }
+}
+
+function applyPress(el: HTMLButtonElement, variant: SplitButtonVariant) {
+  const isDanger = variant === 'danger' || variant === 'danger-outline' || variant === 'danger-ghost';
+  const ring = isDanger ? 'var(--lucent-danger-default)' : 'var(--lucent-accent-default)';
+  el.style.transform = 'translateY(1px)';
+  el.style.boxShadow = `0 0 0 2px var(--lucent-surface), 0 0 0 4px ${ring}`;
+  el.dataset.pressed = '1';
+}
+
+function removePress(el: HTMLButtonElement) {
+  el.style.transform = '';
+  el.style.boxShadow = '';
+  delete el.dataset.pressed;
+}
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+export function SplitButton({
+  children,
+  onClick,
+  menuItems,
+  variant = 'primary',
+  size = 'md',
+  bordered = true,
+  menuPlacement = 'bottom-end',
+  disabled,
+  loading = false,
+  leftIcon,
+  style,
+}: SplitButtonProps) {
+  const isDisabled = disabled ?? loading;
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  const sizeS = sizeStyles[size];
+  const radius = sizeS.borderRadius ?? 'var(--lucent-radius-lg)';
+  const px = chevronSizePx[size];
+
+  const disabledOverrides: CSSProperties = isDisabled ? {
+    background: 'color-mix(in srgb, var(--lucent-surface-secondary) 70%, var(--lucent-border-default))',
+    color: 'color-mix(in srgb, var(--lucent-text-disabled) 50%, var(--lucent-border-default))',
+    borderColor: 'transparent',
+  } : {};
+
+  // Shared base for both halves — each is a fully self-contained button
+  const btnBase: CSSProperties = {
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 'var(--lucent-space-2)',
+    fontFamily: 'var(--lucent-font-family-base)',
+    fontWeight: 'var(--lucent-font-weight-medium)',
+    lineHeight: 1,
+    letterSpacing: '0.01em',
+    cursor: isDisabled ? 'not-allowed' : 'pointer',
+    outline: 'none',
+    margin: 0,
+    boxSizing: 'border-box',
+    whiteSpace: 'nowrap',
+    transition: 'background var(--lucent-duration-fast) var(--lucent-easing-default), border-color var(--lucent-duration-fast) var(--lucent-easing-default), box-shadow var(--lucent-duration-fast) var(--lucent-easing-default), transform 80ms var(--lucent-easing-default)',
+    height: sizeS.height,
+    fontSize: sizeS.fontSize,
+    ...variantStyles[variant],
+    ...(bordered === false && { border: 'none' }),
+    ...disabledOverrides,
+  };
+
+  // Inner corners get a subtle radius — one step below the outer radius
+  const innerRadius = radius === 'var(--lucent-radius-md)' ? 'var(--lucent-radius-sm)' : 'var(--lucent-radius-sm)';
+  const primaryRadius = `${radius} ${innerRadius} ${innerRadius} ${radius}`;
+  const chevronRadius = `${innerRadius} ${radius} ${radius} ${innerRadius}`;
+
+  return (
+    <div
+      role="group"
+      aria-label={typeof children === 'string' ? children : 'Split button'}
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 'calc(var(--lucent-space-1) / 2)',
+        ...style,
+      }}
+    >
+      {/* ── Primary button ── */}
+      <button
+        type="button"
+        disabled={isDisabled}
+        aria-busy={loading}
+        onClick={onClick}
+        onMouseEnter={(e) => { if (!isDisabled) applyHover(e.currentTarget, variant, bordered); }}
+        onMouseLeave={(e) => { if (!isDisabled) removeHover(e.currentTarget, variant, bordered); }}
+        onMouseDown={(e) => { if (!isDisabled) applyPress(e.currentTarget, variant); }}
+        onMouseUp={(e) => { removePress(e.currentTarget); }}
+        onFocus={(e) => {
+          if (!e.currentTarget.dataset.pressed) {
+            e.currentTarget.style.boxShadow = '0 0 0 3px var(--lucent-accent-subtle)';
+          }
+        }}
+        onBlur={(e) => { e.currentTarget.style.boxShadow = ''; }}
+        style={{
+          ...btnBase,
+          borderRadius: primaryRadius,
+          padding: variant === 'ghost' || variant === 'danger-ghost'
+            ? `0 ${sizeS.paddingInner} 0 ${sizeS.paddingOuter}`
+            : `0 ${sizeS.paddingOuter}`,
+        }}
+      >
+        {leftIcon}
+        {loading ? <SplitButtonSpinner /> : children}
+      </button>
+
+      {/* ── Chevron trigger wrapped by Menu ── */}
+      <Menu
+        open={menuOpen}
+        onOpenChange={setMenuOpen}
+        placement={menuPlacement}
+        size={menuSizeMap[size]}
+        trigger={
+          <button
+            type="button"
+            disabled={isDisabled}
+            aria-label="More actions"
+            onMouseEnter={(e) => { if (!isDisabled) applyHover(e.currentTarget, variant, bordered); }}
+            onMouseLeave={(e) => { if (!isDisabled) removeHover(e.currentTarget, variant, bordered); }}
+            onMouseDown={(e) => { if (!isDisabled) applyPress(e.currentTarget, variant); }}
+            onMouseUp={(e) => { removePress(e.currentTarget); }}
+            onFocus={(e) => {
+              if (!e.currentTarget.dataset.pressed) {
+                e.currentTarget.style.boxShadow = '0 0 0 3px var(--lucent-accent-subtle)';
+              }
+            }}
+            onBlur={(e) => { e.currentTarget.style.boxShadow = ''; }}
+            style={{
+              ...btnBase,
+              borderRadius: chevronRadius,
+              padding: 0,
+              width: chevronBtnWidth[size],
+            }}
+          >
+            <svg width={px} height={px} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round" aria-hidden style={{ flexShrink: 0, transition: 'transform var(--lucent-duration-fast) var(--lucent-easing-default)', ...(menuOpen && { transform: 'rotate(180deg)' }) }}>
+              <polyline points="6 9 12 15 18 9" />
+            </svg>
+          </button>
+        }
+      >
+        {menuItems.map((item, i) => (
+          <MenuItem
+            key={i}
+            onSelect={item.onSelect}
+            {...(item.disabled !== undefined && { disabled: item.disabled })}
+            {...(item.danger !== undefined && { danger: item.danger })}
+            {...(item.icon !== undefined && { icon: item.icon })}
+          >
+            {item.label}
+          </MenuItem>
+        ))}
+      </Menu>
+    </div>
+  );
+}
+
+SplitButton.displayName = 'SplitButton';
+
+// ─── Spinner (same pattern as Button) ────────────────────────────────────────
+
+function SplitButtonSpinner() {
+  return (
+    <svg width={14} height={14} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round" aria-hidden style={{ animation: 'lucent-spin 0.7s linear infinite', flexShrink: 0 }}>
+      <style>{`@keyframes lucent-spin { to { transform: rotate(360deg); } }`}</style>
+      <path d="M12 2a10 10 0 0 1 10 10" />
+    </svg>
+  );
+}

--- a/src/components/atoms/SplitButton/index.ts
+++ b/src/components/atoms/SplitButton/index.ts
@@ -1,0 +1,3 @@
+export { SplitButton } from './SplitButton.js';
+export type { SplitButtonProps, SplitButtonVariant, SplitButtonSize, SplitButtonMenuItem } from './SplitButton.js';
+export { COMPONENT_MANIFEST as SplitButtonManifest } from './SplitButton.manifest.js';

--- a/src/components/atoms/index.ts
+++ b/src/components/atoms/index.ts
@@ -24,3 +24,5 @@ export * from './SegmentedControl/index.js';
 export * from './Stack/index.js';
 export * from './Row/index.js';
 export * from './Progress/index.js';
+export * from './SplitButton/index.js';
+export * from './ButtonGroup/index.js';

--- a/src/manifest/examples/button.manifest.ts
+++ b/src/manifest/examples/button.manifest.ts
@@ -11,11 +11,12 @@ export const ButtonManifest: ComponentManifest = {
   designIntent:
     'Buttons communicate available actions. Variant conveys hierarchy: use "primary" for the ' +
     'single most important action in a view, "secondary" for supporting actions, "ghost" for ' +
-    'low-emphasis actions in dense UIs, "outline" for bordered buttons with no fill, and "danger" exclusively for destructive or irreversible ' +
+    'low-emphasis actions in dense UIs, "outline" for bordered buttons with transparent background, and "danger" exclusively for destructive or irreversible ' +
     'operations. Use "danger-ghost" for low-emphasis destructive actions (red text, no fill) and ' +
-    '"danger-outline" for bordered destructive buttons. Size should match surrounding content density — prefer "md" as the default, ' +
+    '"danger-outline" for bordered destructive buttons (also transparent background). Size should match surrounding content density — prefer "md" as the default, ' +
     '"sm" for toolbars or tables, "xs" for compact UIs like customizer panels, and "2xs" for ' +
-    'ultra-dense inline controls (~22px height) such as table-inline actions or toolbar icon triggers.',
+    'ultra-dense inline controls (~22px height) such as table-inline actions or toolbar icon triggers. ' +
+    'Icon-only buttons (leftIcon/rightIcon without children) automatically render as square with aspect-ratio: 1.',
   props: [
     {
       name: 'variant',
@@ -50,8 +51,8 @@ export const ButtonManifest: ComponentManifest = {
     {
       name: 'children',
       type: 'ReactNode',
-      required: true,
-      description: 'Button label or content.',
+      required: false,
+      description: 'Button label or content. Omit for icon-only buttons (provide leftIcon or rightIcon instead).',
     },
     {
       name: 'disabled',
@@ -166,6 +167,11 @@ export const ButtonManifest: ComponentManifest = {
     {
       title: 'Dense inline action',
       code: `<Button variant="ghost" size="2xs" leftIcon={<RefreshIcon />}>Retry</Button>`,
+    },
+    {
+      title: 'Icon-only (square)',
+      code: `<Button variant="outline" size="2xs" leftIcon={<CloseIcon />} aria-label="Close" />`,
+      description: 'Omitting children auto-sizes the button as a square via aspect-ratio: 1.',
     },
   ],
   compositionGraph: [],


### PR DESCRIPTION
SplitButton pairs a primary action with a chevron dropdown for secondary actions. Each half is an independent button separated by a token-scaled gap with subtle inner corner radius. Composes Menu molecule for dropdown keyboard navigation, positioning, and portal rendering. All 7 variants, 5 sizes, disabled, loading, leftIcon, and menu item icons supported.

ButtonGroup visually groups Button/SplitButton children with a small gap and flattened inner corners so the set reads as a unit.

Also updates Button: increased horizontal padding one step across all sizes, icon-only buttons auto-size as squares, outline/danger-outline backgrounds changed from surface to transparent.

Closes #90