### PR TITLE
feat: add NavMenu molecule with sliding highlight pill

### DIFF
--- a/dev/ComponentPreview.tsx
+++ b/dev/ComponentPreview.tsx
@@ -58,6 +58,7 @@ import { Row as RowAtom } from '../src/components/atoms/Row/index.js';
 import { Progress } from '../src/components/atoms/Progress/index.js';
 import { SplitButton } from '../src/components/atoms/SplitButton/index.js';
 import { ButtonGroup } from '../src/components/atoms/ButtonGroup/index.js';
+import { NavMenu } from '../src/components/molecules/NavMenu/index.js';
 import type { LucentTokens, Theme, ThemeAnchors, UploadFile } from '../src/index.js';
 
 // ─── Palette map ────────────────────────────────────────────────────────────
@@ -123,7 +124,7 @@ function ToastButtons({ position, onChangePosition }: { position: ToastPosition;
 
 function NavIcon() {
   return (
-    <svg width={14} height={14} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+    <svg width="1.2em" height="1.2em" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" aria-hidden>
       <rect x="3" y="3" width="7" height="7" /><rect x="14" y="3" width="7" height="7" /><rect x="14" y="14" width="7" height="7" /><rect x="3" y="14" width="7" height="7" />
     </svg>
   );
@@ -398,18 +399,34 @@ function Inner({
   const { tokens } = useLucent();
   const [componentFilter, setComponentFilter] = useState('');
 
-  const allSections = [
-    'Text', 'Input', 'Textarea', 'FormField', 'SearchInput', 'Card', 'Alert',
-    'EmptyState', 'Skeleton', 'Checkbox', 'Radio', 'Toggle', 'Slider', 'CodeBlock',
-    'Table', 'ColorSwatch', 'ColorPicker', 'SegmentedControl', 'Select', 'Chip',
-    'Tooltip', 'Icon', 'Button', 'Avatar', 'Spinner', 'Divider',
-    'Breadcrumb', 'Tabs', 'Collapsible', 'NavLink', 'PageLayout', 'DataTable',
-    'CommandPalette', 'MultiSelect', 'DatePicker', 'DateRangePicker', 'FileUpload', 'Timeline', 'Menu', 'Toast',
-    'Stack', 'Row', 'Progress', 'SplitButton', 'ButtonGroup',
-  ];
+  const sectionGroups: Record<string, { label: string; tier: 'atom' | 'molecule'; items: string[] }> = {
+    buttons:     { label: 'Buttons & Actions', tier: 'atom', items: ['Button', 'SplitButton', 'ButtonGroup', 'Toggle', 'SegmentedControl'] },
+    inputs:      { label: 'Input Fields',      tier: 'atom', items: ['Input', 'Textarea', 'Select', 'Checkbox', 'Radio', 'Slider', 'ColorPicker', 'ColorSwatch'] },
+    text:        { label: 'Text & Labels',      tier: 'atom', items: ['Text', 'Badge', 'Chip', 'Tag', 'Icon', 'Tooltip', 'CodeBlock'] },
+    media:       { label: 'Media & Status',     tier: 'atom', items: ['Avatar', 'Spinner', 'Progress', 'Divider'] },
+    layout:      { label: 'Layout',             tier: 'atom', items: ['Stack', 'Row', 'Table'] },
+    forms:       { label: 'Forms',              tier: 'molecule', items: ['FormField', 'SearchInput', 'MultiSelect', 'DatePicker', 'DateRangePicker', 'FileUpload'] },
+    containers:  { label: 'Containers',         tier: 'molecule', items: ['Card', 'Alert', 'EmptyState', 'Skeleton', 'Collapsible'] },
+    navigation:  { label: 'Navigation',         tier: 'molecule', items: ['Breadcrumb', 'Tabs', 'NavLink', 'NavMenu', 'PageLayout'] },
+    data:        { label: 'Data & Tables',      tier: 'molecule', items: ['DataTable', 'Timeline'] },
+    overlays:    { label: 'Overlays & Menus',   tier: 'molecule', items: ['Menu', 'CommandPalette', 'Toast'] },
+  };
+
+  const allSections = Object.values(sectionGroups).flatMap(g => g.items);
+
+  // Groups where clicking the parent selects all children (not a specific one)
+  const selectAllGroups = new Set(['text']);
 
   const filterLower = componentFilter.toLowerCase();
-  const showSection = (name: string) => !filterLower || name.toLowerCase().includes(filterLower);
+  const showSection = (name: string) => {
+    if (!filterLower) return true;
+    if (componentFilter.startsWith('group:')) {
+      const groupKey = componentFilter.slice(6);
+      const group = sectionGroups[groupKey];
+      return group ? group.items.includes(name) : false;
+    }
+    return name.toLowerCase().includes(filterLower);
+  };
 
   const [inputVal, setInputVal] = useState('');
   const [textareaVal, setTextareaVal] = useState('');
@@ -423,6 +440,9 @@ function Inner({
   const [searchQuery, setSearchQuery] = useState('');
   const [alertDismissed, setAlertDismissed] = useState(false);
   const [menuSort, setMenuSort] = useState('name');
+  const [navInverse, setNavInverse] = useState(false);
+  const [navIcons, setNavIcons] = useState(false);
+  const [navSize, setNavSize] = useState<'sm' | 'md' | 'lg'>('sm');
 
   // Scale preset state
   const [density, setDensity] = useState<DensityPreset>('default');
@@ -526,59 +546,102 @@ function Inner({
         .map((f, i) => ({ id: i, label: f }))
     : [];
 
+  const atomGroups = Object.entries(sectionGroups).filter(([, g]) => g.tier === 'atom');
+  const moleculeGroups = Object.entries(sectionGroups).filter(([, g]) => g.tier === 'molecule');
+
   const navSidebar = (
-    <div style={{ padding: tokens.space4, display: 'flex', flexDirection: 'column', gap: tokens.space1 }}>
-      <div style={{ marginBottom: tokens.space2 }}>
-        <input
-          type="text"
-          value={componentFilter}
-          onChange={(e) => setComponentFilter(e.target.value)}
-          placeholder="Filter…"
-          style={{
-            width: '100%',
-            height: 30,
-            padding: '0 8px',
-            boxSizing: 'border-box',
-            border: `1px solid ${tokens.borderDefault}`,
-            borderRadius: tokens.radiusMd,
-            background: tokens.surface,
-            color: tokens.textPrimary,
-            fontFamily: tokens.fontFamilyBase,
-            fontSize: tokens.fontSizeXs,
-            outline: 'none',
-          }}
+    <div style={{ padding: tokens.space3, display: 'flex', flexDirection: 'column', gap: tokens.space2 }}>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: tokens.space2 }}>
+        <SegmentedControl
+          size="sm"
+          options={[{ value: 'sm', label: 'SM' }, { value: 'md', label: 'MD' }, { value: 'lg', label: 'LG' }]}
+          value={navSize}
+          onChange={(v) => setNavSize(v as 'sm' | 'md' | 'lg')}
         />
+        <div style={{ display: 'flex', alignItems: 'center', gap: tokens.space3 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: tokens.space2 }}>
+            <Text size="xs" color="secondary">Inverse</Text>
+            <Toggle size="sm" checked={navInverse} onChange={(e) => setNavInverse(e.target.checked)} />
+          </div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: tokens.space2 }}>
+            <Text size="xs" color="secondary">Icons</Text>
+            <Toggle size="sm" checked={navIcons} onChange={(e) => setNavIcons(e.target.checked)} />
+          </div>
+        </div>
       </div>
-      {allSections.filter(s => showSection(s)).map(name => (
-        <NavLink
-          key={name}
-          href={`#section-${name}`}
-          onClick={(e: React.MouseEvent) => {
-            e.preventDefault();
-            setComponentFilter(name);
-          }}
-          isActive={componentFilter === name}
-          inverse
-        >
-          {name}
-        </NavLink>
-      ))}
-      {componentFilter && (
-        <button
+      <NavMenu orientation="vertical" size={navSize} inverse={navInverse} hasIcons={navIcons}>
+        <NavMenu.Item
+          as="button"
+          isActive={!componentFilter}
           onClick={() => setComponentFilter('')}
-          style={{
-            border: 'none',
-            background: 'none',
-            color: tokens.textSecondary,
-            cursor: 'pointer',
-            fontSize: tokens.fontSizeXs,
-            padding: `${tokens.space1} ${tokens.space2}`,
-            textAlign: 'left',
-          }}
+          icon={navIcons ? <NavIcon /> : undefined}
         >
-          Clear filter
-        </button>
-      )}
+          All components
+        </NavMenu.Item>
+        <NavMenu.Separator />
+        <NavMenu.Group label="Atoms">
+          {atomGroups.map(([key, group]) => {
+            const isSelectAll = selectAllGroups.has(key);
+            return (
+              <NavMenu.Item
+                key={key}
+                as="button"
+                isActive={isSelectAll
+                  ? componentFilter === `group:${key}`
+                  : group.items.includes(componentFilter)
+                }
+                onClick={() => setComponentFilter(isSelectAll ? `group:${key}` : group.items[0])}
+                icon={navIcons ? <NavIcon /> : undefined}
+              >
+                {group.label}
+                <NavMenu.Sub>
+                  {group.items.map(name => (
+                    <NavMenu.Item
+                      key={name}
+                      as="button"
+                      isActive={componentFilter === name}
+                      onClick={() => setComponentFilter(name)}
+                    >
+                      {name}
+                    </NavMenu.Item>
+                  ))}
+                </NavMenu.Sub>
+              </NavMenu.Item>
+            );
+          })}
+          <NavMenu.Item as="button" isActive={componentFilter === 'atoms-overview'} onClick={() => setComponentFilter('atoms-overview')} icon={navIcons ? <NavIcon /> : undefined}>Overview</NavMenu.Item>
+          <NavMenu.Item as="button" isActive={componentFilter === 'atoms-guidelines'} onClick={() => setComponentFilter('atoms-guidelines')} icon={navIcons ? <NavIcon /> : undefined}>Guidelines</NavMenu.Item>
+        </NavMenu.Group>
+        <NavMenu.Group label="Molecules">
+          {moleculeGroups.map(([key, group]) => (
+            <NavMenu.Item
+              key={key}
+              as="button"
+              isActive={group.items.includes(componentFilter)}
+              onClick={() => setComponentFilter(group.items[0])}
+              icon={navIcons ? <NavIcon /> : undefined}
+            >
+              {group.label}
+              <NavMenu.Sub>
+                {group.items.map(name => (
+                  <NavMenu.Item
+                    key={name}
+                    as="button"
+                    isActive={componentFilter === name}
+                    onClick={() => setComponentFilter(name)}
+                  >
+                    {name}
+                  </NavMenu.Item>
+                ))}
+              </NavMenu.Sub>
+            </NavMenu.Item>
+          ))}
+          <NavMenu.Item as="button" isActive={componentFilter === 'mol-patterns'} onClick={() => setComponentFilter('mol-patterns')} icon={navIcons ? <NavIcon /> : undefined}>Patterns</NavMenu.Item>
+        </NavMenu.Group>
+        <NavMenu.Separator />
+        <NavMenu.Item as="button" isActive={componentFilter === 'changelog'} onClick={() => setComponentFilter('changelog')} icon={navIcons ? <NavIcon /> : undefined}>Changelog</NavMenu.Item>
+        <NavMenu.Item as="button" isActive={componentFilter === 'about'} onClick={() => setComponentFilter('about')} icon={navIcons ? <NavIcon /> : undefined}>About</NavMenu.Item>
+      </NavMenu>
     </div>
   );
 
@@ -756,7 +819,7 @@ function Inner({
       headerHeight={48}
       chromeBackground="bgSubtle"
       mainStyle={{ background: tokens.bgBase }}
-      {...(tab === 'components' && { sidebar: navSidebar, sidebarWidth: 180 })}
+      {...(tab === 'components' && { sidebar: navSidebar, sidebarWidth: navSize === 'lg' ? 280 : navSize === 'md' ? 250 : 220 })}
       {...(tab === 'components' && { rightSidebar: customizerSidebar, rightSidebarWidth: 260 })}
     >
       {tab === 'components' ? (
@@ -2442,6 +2505,73 @@ function Inner({
               </RowAtom>
             </StackAtom>
           </Card>
+        </Row>
+      </Section>
+
+      <Section title="NavMenu" tokens={tokens} hidden={!showSection('NavMenu')}>
+        <Row label="Vertical — child active (parent highlights)" tokens={tokens}>
+          <div style={{ width: 220, background: tokens.bgSubtle, borderRadius: tokens.radiusMd, padding: tokens.space3 }}>
+            <NavMenu orientation="vertical">
+              <NavMenu.Item href="#" icon={<NavIcon />}>Dashboard</NavMenu.Item>
+              <NavMenu.Item href="#" icon={<NavIcon />} badge={<Chip size="sm" variant="neutral">12</Chip>}>Projects</NavMenu.Item>
+              <NavMenu.Item icon={<NavIcon />} badge={<Chip size="sm" variant="accent">3</Chip>}>
+                Settings
+                <NavMenu.Sub>
+                  <NavMenu.Item href="#" isActive>General</NavMenu.Item>
+                  <NavMenu.Item href="#">Team</NavMenu.Item>
+                  <NavMenu.Item href="#">Billing</NavMenu.Item>
+                </NavMenu.Sub>
+              </NavMenu.Item>
+              <NavMenu.Item href="#" icon={<NavIcon />} disabled>Disabled</NavMenu.Item>
+            </NavMenu>
+          </div>
+        </Row>
+        <Row label="Vertical with groups (inverse)" tokens={tokens}>
+          <div style={{ width: 220, background: tokens.bgSubtle, borderRadius: tokens.radiusMd, padding: tokens.space3 }}>
+            <NavMenu orientation="vertical" inverse>
+              <NavMenu.Group label="Main">
+                <NavMenu.Item href="#" isActive>Dashboard</NavMenu.Item>
+                <NavMenu.Item href="#" badge={<Chip size="sm" variant="neutral">5</Chip>}>Analytics</NavMenu.Item>
+              </NavMenu.Group>
+              <NavMenu.Separator />
+              <NavMenu.Group label="Admin" defaultOpen={false}>
+                <NavMenu.Item href="#">Users</NavMenu.Item>
+                <NavMenu.Item href="#">Roles</NavMenu.Item>
+              </NavMenu.Group>
+            </NavMenu>
+          </div>
+        </Row>
+        <Row label="Compact (size=sm)" tokens={tokens}>
+          <div style={{ width: 200, background: tokens.bgSubtle, borderRadius: tokens.radiusMd, padding: tokens.space2 }}>
+            <NavMenu orientation="vertical" size="sm">
+              <NavMenu.Item href="#" icon={<NavIcon />} isActive>Dashboard</NavMenu.Item>
+              <NavMenu.Item href="#" icon={<NavIcon />}>Projects</NavMenu.Item>
+              <NavMenu.Item icon={<NavIcon />}>
+                Settings
+                <NavMenu.Sub>
+                  <NavMenu.Item href="#">General</NavMenu.Item>
+                  <NavMenu.Item href="#">Team</NavMenu.Item>
+                </NavMenu.Sub>
+              </NavMenu.Item>
+            </NavMenu>
+          </div>
+        </Row>
+        <Row label="Horizontal (top bar)" tokens={tokens}>
+          <div style={{ borderBottom: `1px solid ${tokens.borderDefault}`, padding: `0 ${tokens.space2}` }}>
+            <NavMenu orientation="horizontal">
+              <NavMenu.Item href="#" isActive>Dashboard</NavMenu.Item>
+              <NavMenu.Item href="#">Projects</NavMenu.Item>
+              <NavMenu.Item>
+                Settings
+                <NavMenu.Sub>
+                  <NavMenu.Item href="#" isActive>General</NavMenu.Item>
+                  <NavMenu.Item href="#">Team</NavMenu.Item>
+                  <NavMenu.Item href="#">Billing</NavMenu.Item>
+                </NavMenu.Sub>
+              </NavMenu.Item>
+              <NavMenu.Item href="#" disabled>Disabled</NavMenu.Item>
+            </NavMenu>
+          </div>
         </Row>
       </Section>
       </div>

--- a/src/components/molecules/NavMenu/NavMenu.manifest.ts
+++ b/src/components/molecules/NavMenu/NavMenu.manifest.ts
@@ -1,0 +1,265 @@
+import type { ComponentManifest } from '../../../manifest/types.js';
+
+export const COMPONENT_MANIFEST: ComponentManifest = {
+  id: 'nav-menu',
+  name: 'NavMenu',
+  tier: 'molecule',
+  domain: 'neutral',
+  specVersion: '0.1',
+
+  description:
+    'Multi-level navigation menu supporting vertical (sidebar) and horizontal (top bar) orientations with a sliding highlight pill, CSS-driven hover states, collapsible groups, and nested sub-menus.',
+
+  designIntent:
+    'NavMenu provides hierarchical navigation for sidebar and top-bar layouts. ' +
+    'A single sliding highlight pill follows the active item, driven entirely from the root via DOM measurement — ' +
+    'the root queries for data-active / data-active-parent attributes and positions an absolutely-placed pill ' +
+    'using requestAnimationFrame. MutationObserver and ResizeObserver auto-trigger re-measurement; ' +
+    'aria-hidden ancestry is used to detect collapsed items (not offsetHeight), eliminating all timeout-based coordination. ' +
+    'Hover states use a CSS rule on [data-lucent-navitem] with :not() exclusions for active, parent-active, hint, and disabled states, ' +
+    'rendering a 5% translucent text-primary tint that never conflicts with the accent pill. ' +
+    'In vertical orientation, parent items expand inline with smooth height animation (same pattern as Collapsible) ' +
+    'and children are indented by depth level. When a parent with an active child is collapsed, the pill slides ' +
+    'to the parent button with a lighter visual style (12% accent tint or surface-secondary in inverse mode) ' +
+    'so text remains readable without on-accent color. When re-expanded, the pill slides back to the child. ' +
+    'Parent items support "self-active" mode: setting isActive on a parent with no active children ' +
+    'highlights the parent with the full accent pill, useful for section-level pages that represent all children. ' +
+    'Inverse mode uses surface background with accent right-border (inset -3px) and elevation shadow. ' +
+    'The hasIcons prop controls left-padding alignment globally: when true, items use tighter padding (space-2) ' +
+    'and group headers align with icon start; sub-menu children inherit parentHasIcon via context so their ' +
+    'text aligns with the parent label text regardless of whether they have icons themselves. ' +
+    'In horizontal orientation, parent items show dropdown sub-menus on hover/click with enter/exit animation ' +
+    'and viewport collision detection. Groups are flattened in horizontal mode. ' +
+    'Three sizes (sm/md/lg) scale font, padding, gap, and icon width via a token map. ' +
+    'The compound API (NavMenu.Item, NavMenu.Group, NavMenu.Sub, NavMenu.Separator) keeps the tree declarative.',
+
+  props: [
+    {
+      name: 'orientation',
+      type: 'enum',
+      required: false,
+      default: '"vertical"',
+      description: 'Layout direction. Vertical for sidebars, horizontal for top navigation bars.',
+      enumValues: ['vertical', 'horizontal'],
+    },
+    {
+      name: 'inverse',
+      type: 'boolean',
+      required: false,
+      default: 'false',
+      description:
+        'Uses surface background with accent right-border and elevation shadow instead of accent fill for the active highlight pill.',
+    },
+    {
+      name: 'size',
+      type: 'enum',
+      required: false,
+      default: '"md"',
+      description: 'Size variant controlling font size, padding, gap, and icon width.',
+      enumValues: ['sm', 'md', 'lg'],
+    },
+    {
+      name: 'hasIcons',
+      type: 'boolean',
+      required: false,
+      default: 'false',
+      description:
+        'Whether items use icons. Tightens left padding on items and group headers so text aligns with icon positions. ' +
+        'Sub-menu children automatically inherit parent icon awareness via context for consistent text alignment.',
+    },
+    {
+      name: 'aria-label',
+      type: 'string',
+      required: false,
+      default: '"Navigation"',
+      description: 'Accessible label for the root <nav> element.',
+    },
+    {
+      name: 'style',
+      type: 'object',
+      required: false,
+      description: 'Inline style overrides for the root <nav> element.',
+    },
+  ],
+
+  usageExamples: [
+    {
+      title: 'Vertical sidebar with icons',
+      code: `<NavMenu orientation="vertical" hasIcons>
+  <NavMenu.Item icon={<DashIcon />} href="/dashboard" isActive>Dashboard</NavMenu.Item>
+  <NavMenu.Group label="Workspace">
+    <NavMenu.Item icon={<FolderIcon />} href="/projects">Projects</NavMenu.Item>
+    <NavMenu.Item icon={<GearIcon />}>
+      Settings
+      <NavMenu.Sub>
+        <NavMenu.Item href="/settings/general" isActive>General</NavMenu.Item>
+        <NavMenu.Item href="/settings/team">Team</NavMenu.Item>
+      </NavMenu.Sub>
+    </NavMenu.Item>
+  </NavMenu.Group>
+  <NavMenu.Separator />
+  <NavMenu.Item icon={<HelpIcon />} href="/help">Help</NavMenu.Item>
+</NavMenu>`,
+      description:
+        'Sidebar with icons, groups, and nested sub-menu. hasIcons tightens padding so group headers align with icons ' +
+        'and sub-menu children align with parent text.',
+    },
+    {
+      title: 'Vertical sidebar without icons',
+      code: `<NavMenu orientation="vertical">
+  <NavMenu.Item href="/dashboard" isActive>Dashboard</NavMenu.Item>
+  <NavMenu.Group label="Workspace">
+    <NavMenu.Item href="/projects">Projects</NavMenu.Item>
+    <NavMenu.Item>
+      Settings
+      <NavMenu.Sub>
+        <NavMenu.Item href="/settings/general">General</NavMenu.Item>
+        <NavMenu.Item href="/settings/team">Team</NavMenu.Item>
+      </NavMenu.Sub>
+    </NavMenu.Item>
+  </NavMenu.Group>
+</NavMenu>`,
+      description:
+        'Without hasIcons, items and group headers use standard padding (space-4) for comfortable text-only layout.',
+    },
+    {
+      title: 'Horizontal top navigation',
+      code: `<NavMenu orientation="horizontal">
+  <NavMenu.Item href="/dashboard" isActive>Dashboard</NavMenu.Item>
+  <NavMenu.Item href="/projects">Projects</NavMenu.Item>
+  <NavMenu.Item>
+    Settings
+    <NavMenu.Sub>
+      <NavMenu.Item href="/settings/general">General</NavMenu.Item>
+      <NavMenu.Item href="/settings/team">Team</NavMenu.Item>
+    </NavMenu.Sub>
+  </NavMenu.Item>
+</NavMenu>`,
+      description:
+        'Top bar layout. Parent items show dropdown sub-menus on hover/click with viewport collision detection.',
+    },
+    {
+      title: 'Inverse mode with section groups',
+      code: `<NavMenu orientation="vertical" inverse>
+  <NavMenu.Group label="Main">
+    <NavMenu.Item href="/dashboard" isActive>Dashboard</NavMenu.Item>
+    <NavMenu.Item href="/analytics">Analytics</NavMenu.Item>
+  </NavMenu.Group>
+  <NavMenu.Separator />
+  <NavMenu.Group label="Admin" defaultOpen={false}>
+    <NavMenu.Item href="/users">Users</NavMenu.Item>
+    <NavMenu.Item href="/roles">Roles</NavMenu.Item>
+  </NavMenu.Group>
+</NavMenu>`,
+      description:
+        'Inverse highlight: surface background with accent right-border and elevation shadow. Text stays text-primary.',
+    },
+    {
+      title: 'Self-active parent (section-level page)',
+      code: `<NavMenu orientation="vertical" hasIcons>
+  <NavMenu.Item isActive icon={<TextIcon />}>
+    Text & Labels
+    <NavMenu.Sub>
+      <NavMenu.Item href="/text">Text</NavMenu.Item>
+      <NavMenu.Item href="/badge">Badge</NavMenu.Item>
+      <NavMenu.Item href="/chip">Chip</NavMenu.Item>
+    </NavMenu.Sub>
+  </NavMenu.Item>
+  <NavMenu.Item icon={<InputIcon />}>
+    Input Fields
+    <NavMenu.Sub>
+      <NavMenu.Item href="/input" isActive>Input</NavMenu.Item>
+      <NavMenu.Item href="/select">Select</NavMenu.Item>
+    </NavMenu.Sub>
+  </NavMenu.Item>
+</NavMenu>`,
+      description:
+        'Setting isActive on a parent with no active children gives it the full accent highlight. ' +
+        'The sub-nav expands but no child is individually selected — the parent represents all items. ' +
+        'Clicking a specific child moves the highlight to that child.',
+    },
+    {
+      title: 'Compact sidebar (sm size)',
+      code: `<NavMenu orientation="vertical" size="sm" hasIcons>
+  <NavMenu.Item href="/dash" icon={<DashIcon />} isActive>Dashboard</NavMenu.Item>
+  <NavMenu.Item href="/projects" icon={<FolderIcon />}>Projects</NavMenu.Item>
+  <NavMenu.Item icon={<GearIcon />}>
+    Settings
+    <NavMenu.Sub>
+      <NavMenu.Item href="/settings/general">General</NavMenu.Item>
+      <NavMenu.Item href="/settings/team">Team</NavMenu.Item>
+    </NavMenu.Sub>
+  </NavMenu.Item>
+</NavMenu>`,
+      description: 'Small size variant for compact sidebar layouts with tighter padding and smaller font.',
+    },
+    {
+      title: 'Badges and disabled items',
+      code: `<NavMenu orientation="vertical" hasIcons>
+  <NavMenu.Item href="/inbox" icon={<InboxIcon />} badge={<Chip size="sm" variant="accent">3</Chip>}>Inbox</NavMenu.Item>
+  <NavMenu.Item href="/settings" icon={<GearIcon />} isActive>Settings</NavMenu.Item>
+  <NavMenu.Item href="/archive" icon={<ArchiveIcon />} disabled>Archived</NavMenu.Item>
+</NavMenu>`,
+      description: 'Items with badge counts and disabled state. Disabled items use not-allowed cursor and muted text.',
+    },
+    {
+      title: 'Polymorphic items with React Router',
+      code: `<NavMenu orientation="vertical">
+  <NavMenu.Item as={Link} href="/dashboard" isActive>Dashboard</NavMenu.Item>
+  <NavMenu.Item as={Link} href="/projects">Projects</NavMenu.Item>
+</NavMenu>`,
+      description: 'Using the "as" prop to render items as React Router Link components instead of anchor tags.',
+    },
+  ],
+
+  compositionGraph: [
+    {
+      componentId: 'nav-menu-item',
+      componentName: 'NavMenu.Item',
+      role: 'Individual navigation link or parent toggle. Sets data-active when self-active, data-active-parent when collapsed with an active child. Uses data-lucent-navitem for CSS hover targeting.',
+      required: true,
+    },
+    {
+      componentId: 'nav-menu-sub',
+      componentName: 'NavMenu.Sub',
+      role: 'Marker wrapper for nested sub-menu children inside a parent NavMenu.Item.',
+      required: false,
+    },
+    {
+      componentId: 'nav-menu-group',
+      componentName: 'NavMenu.Group',
+      role: 'Section grouping with optional uppercase label header and independent collapse. Header left padding responds to hasIcons context.',
+      required: false,
+    },
+    {
+      componentId: 'nav-menu-separator',
+      componentName: 'NavMenu.Separator',
+      role: 'Visual divider between sections. Horizontal line in vertical mode, vertical line in horizontal mode.',
+      required: false,
+    },
+  ],
+
+  accessibility: {
+    role: 'navigation',
+    ariaAttributes: [
+      'aria-label on root <nav>',
+      'aria-expanded on parent items with sub-menus',
+      'aria-current="page" on active leaf items',
+      'aria-disabled on disabled items',
+      'aria-hidden on collapsed sub-menu content and the highlight pill',
+      'role="separator" on dividers',
+    ],
+    keyboardInteractions: [
+      'Enter / Space — toggle parent item expand/collapse',
+      'ArrowRight (vertical) / ArrowDown (horizontal) — expand parent item',
+      'ArrowLeft (vertical) / ArrowUp (horizontal) — collapse parent item',
+      'Escape — close open sub-menu',
+    ],
+    notes:
+      'Parent items use aria-expanded to communicate open/closed state. ' +
+      'Active leaf items use aria-current="page". Disabled items use aria-disabled with no click handler. ' +
+      'Collapsed sections are marked aria-hidden="true", which the sliding highlight uses to detect ' +
+      'visibility — items inside aria-hidden containers are skipped in favor of the parent fallback. ' +
+      'Separators use role="separator". The highlight pill is aria-hidden.',
+  },
+};

--- a/src/components/molecules/NavMenu/NavMenu.tsx
+++ b/src/components/molecules/NavMenu/NavMenu.tsx
@@ -1,0 +1,1003 @@
+import {
+  createContext,
+  useContext,
+  useState,
+  useRef,
+  useEffect,
+  useCallback,
+  useLayoutEffect,
+  type CSSProperties,
+  type ReactNode,
+  type MouseEventHandler,
+  type KeyboardEvent,
+} from 'react';
+
+/* ─── Constants ─────────────────────────────────────────────────────────────── */
+
+const ANIM_DURATION = 120; // ms — dropdown enter/exit
+
+const KEYFRAMES = `
+@keyframes lucent-navmenu-open {
+  from { opacity: 0; transform: translateY(-4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@keyframes lucent-navmenu-dropdown-in {
+  from { opacity: 0; transform: scale(0.97) translateY(-2px); }
+  to   { opacity: 1; transform: scale(1) translateY(0); }
+}
+@keyframes lucent-navmenu-dropdown-out {
+  from { opacity: 1; transform: scale(1) translateY(0); }
+  to   { opacity: 0; transform: scale(0.97) translateY(-2px); }
+}
+[data-lucent-navitem]:not([data-active]):not([data-active-parent]):not([data-hint]):not([aria-disabled]):hover {
+  background: color-mix(in srgb, var(--lucent-text-primary) 5%, transparent) !important;
+  color: var(--lucent-text-primary) !important;
+}
+`;
+
+const SPRING = 'cubic-bezier(0.34, 1.56, 0.64, 1)';
+
+/* ─── Size tokens ───────────────────────────────────────────────────────────── */
+
+type NavMenuSize = 'sm' | 'md' | 'lg';
+
+const SIZE_TOKENS: Record<NavMenuSize, {
+  fontSize: string;
+  paddingY: string;
+  paddingX: string;
+  gap: string;
+  itemGap: string;
+  iconWidth: string;
+  nestedFontSize: string;
+}> = {
+  sm: {
+    fontSize: 'var(--lucent-font-size-sm)',
+    paddingY: '5px',
+    paddingX: 'var(--lucent-space-3)',
+    gap: 'var(--lucent-space-2)',
+    itemGap: '0px',
+    iconWidth: 'var(--lucent-space-5)',
+    nestedFontSize: 'var(--lucent-font-size-xs)',
+  },
+  md: {
+    fontSize: 'var(--lucent-font-size-md)',
+    paddingY: '6px',
+    paddingX: 'var(--lucent-space-3)',
+    gap: 'var(--lucent-space-2)',
+    itemGap: '2px',
+    iconWidth: 'var(--lucent-space-5)',
+    nestedFontSize: 'var(--lucent-font-size-sm)',
+  },
+  lg: {
+    fontSize: 'var(--lucent-font-size-lg)',
+    paddingY: 'var(--lucent-space-2)',
+    paddingX: 'var(--lucent-space-4)',
+    gap: 'var(--lucent-space-3)',
+    itemGap: 'var(--lucent-space-1)',
+    iconWidth: 'var(--lucent-space-6)',
+    nestedFontSize: 'var(--lucent-font-size-md)',
+  },
+};
+
+/* ─── Context ───────────────────────────────────────────────────────────────── */
+
+interface NavMenuContextValue {
+  orientation: 'vertical' | 'horizontal';
+  depth: number;
+  inverse: boolean;
+  size: NavMenuSize;
+  hasIcons: boolean;
+  parentHasIcon: boolean;
+  requestMeasure: () => void;
+}
+
+const NavMenuContext = createContext<NavMenuContextValue>({
+  orientation: 'vertical',
+  depth: 0,
+  inverse: false,
+  size: 'md',
+  hasIcons: false,
+  parentHasIcon: false,
+  requestMeasure: () => {},
+});
+
+/* ─── NavMenu (root) ────────────────────────────────────────────────────────── */
+
+export interface NavMenuProps {
+  children: ReactNode;
+  /** Layout direction. Defaults to `"vertical"`. */
+  orientation?: 'vertical' | 'horizontal';
+  /** Uses surface background instead of accent for the active state. */
+  inverse?: boolean;
+  /** Size variant. `"sm"` for compact sidebar layouts. Defaults to `"md"`. */
+  size?: NavMenuSize;
+  /** Whether items use icons. Tightens left padding so group headers align with icons. */
+  hasIcons?: boolean;
+  style?: CSSProperties;
+  /** Accessible label for the `<nav>` element. */
+  'aria-label'?: string;
+}
+
+export function NavMenu({
+  children,
+  orientation = 'vertical',
+  inverse = false,
+  size = 'md',
+  hasIcons = false,
+  style,
+  'aria-label': ariaLabel = 'Navigation',
+}: NavMenuProps) {
+  const styleInjected = useRef(false);
+  if (!styleInjected.current && typeof document !== 'undefined') {
+    const el = document.createElement('style');
+    el.textContent = KEYFRAMES;
+    document.head.appendChild(el);
+    styleInjected.current = true;
+  }
+
+  const tokens = SIZE_TOKENS[size];
+  const navRef = useRef<HTMLElement>(null);
+  const pillRef = useRef<HTMLDivElement>(null);
+  const mounted = useRef(false);
+  const rafId = useRef(0);
+
+  const measure = useCallback(() => {
+    const nav = navRef.current;
+    const pill = pillRef.current;
+    if (!nav || !pill) return;
+
+    // Query for active item (prefer visible child over parent)
+    const active = nav.querySelector('[data-active="true"]') as HTMLElement | null;
+    const parent = nav.querySelector('[data-active-parent="true"]') as HTMLElement | null;
+
+    // Pick target: visible active child first, then parent
+    let target: HTMLElement | null = null;
+    let isParentHighlight = false;
+
+    if (active && !active.closest('[aria-hidden="true"]')) {
+      target = active;
+    } else if (parent && !parent.closest('[aria-hidden="true"]')) {
+      target = parent;
+      isParentHighlight = true;
+    }
+
+    if (!target) {
+      pill.style.opacity = '0';
+      return;
+    }
+
+    const navRect = nav.getBoundingClientRect();
+    const tRect = target.getBoundingClientRect();
+
+    // Gate first animation — no transition on initial render
+    if (!mounted.current) {
+      pill.style.transition = 'none';
+      mounted.current = true;
+    } else {
+      pill.style.transition = [
+        `top 150ms ${SPRING}`,
+        `left 150ms ${SPRING}`,
+        `width 150ms ${SPRING}`,
+        `height 150ms ${SPRING}`,
+        'opacity 100ms ease',
+        'background 150ms ease',
+        'box-shadow 150ms ease',
+      ].join(', ');
+    }
+
+    pill.style.top = `${tRect.top - navRect.top}px`;
+    pill.style.left = `${tRect.left - navRect.left}px`;
+    pill.style.width = `${tRect.width}px`;
+    pill.style.height = `${tRect.height}px`;
+    pill.style.opacity = '1';
+
+    // Parent highlight: lighter surface style; child highlight: full accent
+    if (isParentHighlight) {
+      pill.style.background = inverse
+        ? 'var(--lucent-surface-secondary)'
+        : 'color-mix(in srgb, var(--lucent-accent-default) 12%, transparent)';
+      pill.style.boxShadow = 'none';
+    } else {
+      pill.style.background = inverse
+        ? 'var(--lucent-surface)'
+        : 'var(--lucent-accent-default)';
+      pill.style.boxShadow = inverse
+        ? 'inset -3px 0 0 var(--lucent-accent-default), var(--lucent-shadow-sm)'
+        : 'none';
+    }
+  }, [inverse]);
+
+  const requestMeasure = useCallback(() => {
+    cancelAnimationFrame(rafId.current);
+    rafId.current = requestAnimationFrame(measure);
+  }, [measure]);
+
+  // MutationObserver — watches data-active, data-active-parent, aria-hidden changes
+  useEffect(() => {
+    const nav = navRef.current;
+    if (!nav) return;
+    const mo = new MutationObserver(requestMeasure);
+    mo.observe(nav, {
+      attributes: true,
+      attributeFilter: ['data-active', 'data-active-parent', 'aria-hidden'],
+      subtree: true,
+    });
+    return () => mo.disconnect();
+  }, [requestMeasure]);
+
+  // ResizeObserver — handles density/window resize
+  useEffect(() => {
+    const nav = navRef.current;
+    if (!nav) return;
+    const ro = new ResizeObserver(requestMeasure);
+    ro.observe(nav);
+    return () => ro.disconnect();
+  }, [requestMeasure]);
+
+  // Fonts
+  useEffect(() => {
+    document.fonts.ready.then(requestMeasure);
+  }, [requestMeasure]);
+
+  // Re-measure when children, inverse, or size change
+  useEffect(() => {
+    requestMeasure();
+  }, [children, inverse, size, requestMeasure]);
+
+  return (
+    <NavMenuContext.Provider value={{ orientation, depth: 0, inverse, size, hasIcons, parentHasIcon: false, requestMeasure }}>
+      <nav
+        ref={navRef as React.RefObject<HTMLElement>}
+        aria-label={ariaLabel}
+        style={{
+          display: 'flex',
+          flexDirection: orientation === 'vertical' ? 'column' : 'row',
+          gap: tokens.itemGap,
+          fontFamily: 'var(--lucent-font-family-base)',
+          fontSize: tokens.fontSize,
+          position: 'relative',
+          ...style,
+        }}
+      >
+        {/* Sliding highlight pill — always in DOM */}
+        <div
+          ref={pillRef}
+          aria-hidden
+          style={{
+            position: 'absolute',
+            borderRadius: 'var(--lucent-radius-md)',
+            pointerEvents: 'none',
+            zIndex: 0,
+            opacity: 0,
+            top: 0,
+            left: 0,
+            width: 0,
+            height: 0,
+          }}
+        />
+        {children}
+      </nav>
+    </NavMenuContext.Provider>
+  );
+}
+
+/* ─── NavMenu.Item ──────────────────────────────────────────────────────────── */
+
+export interface NavMenuItemProps {
+  children: ReactNode;
+  href?: string;
+  isActive?: boolean;
+  icon?: ReactNode;
+  badge?: ReactNode;
+  disabled?: boolean;
+  onClick?: MouseEventHandler;
+  /** Polymorphic root element. Defaults to `<a>`. Use e.g. `Link` from react-router. */
+  as?: React.ElementType;
+  style?: CSSProperties;
+}
+
+export function NavMenuItem({
+  children,
+  href,
+  isActive = false,
+  icon,
+  badge,
+  disabled = false,
+  onClick,
+  as,
+  style,
+}: NavMenuItemProps) {
+  const { orientation, depth, inverse, size, parentHasIcon, requestMeasure } = useContext(NavMenuContext);
+  const tokens = SIZE_TOKENS[size];
+
+  // Trigger measurement when active state changes
+  useEffect(() => {
+    requestMeasure();
+  }, [isActive, requestMeasure]);
+
+  // Detect if this item has a NavMenuSub child
+  let subMenu: ReactNode = null;
+  const labelChildren: ReactNode[] = [];
+
+  const childArray = Array.isArray(children) ? children : [children];
+  for (const child of childArray) {
+    if (
+      child != null &&
+      typeof child === 'object' &&
+      'type' in child &&
+      (child as React.ReactElement).type === NavMenuSub
+    ) {
+      subMenu = child;
+    } else {
+      labelChildren.push(child);
+    }
+  }
+
+  if (subMenu) {
+    return (
+      <NavMenuParentItem
+        subMenu={subMenu}
+        orientation={orientation}
+        depth={depth}
+        inverse={inverse}
+        size={size}
+        isActive={isActive}
+        disabled={disabled}
+        {...(icon !== undefined && { icon })}
+        {...(badge !== undefined && { badge })}
+        {...(onClick !== undefined && { onClick })}
+        {...(style !== undefined && { style })}
+      >
+        {labelChildren}
+      </NavMenuParentItem>
+    );
+  }
+
+  const Tag = (as ?? 'a') as React.ElementType;
+
+  return (
+    <Tag
+      data-lucent-navitem=""
+      data-active={isActive || undefined}
+      href={disabled ? undefined : href}
+      onClick={disabled ? undefined : onClick}
+      aria-current={isActive ? 'page' : undefined}
+      aria-disabled={disabled || undefined}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: tokens.gap,
+        padding: orientation === 'vertical'
+          ? `${tokens.paddingY} ${tokens.paddingX} ${tokens.paddingY} ${(icon != null || parentHasIcon) ? 'var(--lucent-space-2)' : 'var(--lucent-space-4)'}`
+          : `${tokens.paddingY} ${tokens.paddingX}`,
+        borderRadius: 'var(--lucent-radius-md)',
+        background: 'transparent',
+        color: disabled
+          ? 'var(--lucent-text-disabled)'
+          : isActive
+          ? (inverse ? 'var(--lucent-text-primary)' : 'var(--lucent-text-on-accent)')
+          : 'var(--lucent-text-secondary)',
+        border: 0,
+        borderBottom: isActive && orientation === 'horizontal'
+          ? '2px solid var(--lucent-accent-default)'
+          : orientation === 'horizontal'
+          ? '2px solid transparent'
+          : 0,
+        boxShadow: 'none',
+        fontFamily: 'var(--lucent-font-family-base)',
+        fontSize: tokens.fontSize,
+        fontWeight: isActive ? 'var(--lucent-font-weight-medium)' : 'var(--lucent-font-weight-regular)',
+        textDecoration: 'none',
+        cursor: disabled ? 'not-allowed' : 'pointer',
+        transition: 'background var(--lucent-duration-fast) var(--lucent-easing-default), color var(--lucent-duration-fast) var(--lucent-easing-default)',
+        userSelect: 'none',
+        boxSizing: 'border-box',
+        position: 'relative',
+        zIndex: 1,
+        whiteSpace: orientation === 'horizontal' ? 'nowrap' : undefined,
+        width: orientation === 'vertical' ? '100%' : undefined,
+        textAlign: 'left',
+        outline: 'none',
+        ...style,
+      }}
+    >
+      {icon != null && (
+        <span style={{ display: 'flex', flexShrink: 0, width: tokens.iconWidth, minWidth: 14, minHeight: 14, alignItems: 'center', justifyContent: 'center', color: 'inherit' }}>{icon}</span>
+      )}
+      <span style={{ flex: 1 }}>{labelChildren}</span>
+      {badge != null && (
+        <span style={{ display: 'flex', flexShrink: 0, marginLeft: 'auto' }}>{badge}</span>
+      )}
+    </Tag>
+  );
+}
+
+/* ─── Parent item (has sub-menu) ────────────────────────────────────────────── */
+
+interface NavMenuParentItemProps {
+  children: ReactNode;
+  subMenu: ReactNode;
+  orientation: 'vertical' | 'horizontal';
+  depth: number;
+  inverse: boolean;
+  size: NavMenuSize;
+  icon?: ReactNode;
+  badge?: ReactNode;
+  isActive?: boolean;
+  disabled?: boolean;
+  onClick?: MouseEventHandler;
+  style?: CSSProperties;
+}
+
+function NavMenuParentItem({
+  children,
+  icon,
+  badge,
+  isActive = false,
+  disabled = false,
+  onClick,
+  style,
+  subMenu,
+  orientation,
+  depth,
+  inverse,
+  size,
+}: NavMenuParentItemProps) {
+  const { hasIcons, requestMeasure } = useContext(NavMenuContext);
+  const tokens = SIZE_TOKENS[size];
+  const [isOpen, setIsOpen] = useState(false);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const [height, setHeight] = useState<number | undefined>(0);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const closeTimer = useRef<ReturnType<typeof setTimeout>>();
+
+  // Track whether any child is active to highlight this parent
+  const hasActiveChild = useHasActiveChild(subMenu);
+
+  // Parent is the active destination (no child selected)
+  const selfActive = isActive && !hasActiveChild;
+  // When collapsed with active child, highlight sits on the parent with lighter style
+  const collapsedWithActiveChild = !selfActive && !isOpen && hasActiveChild;
+  const showHint = isActive || hasActiveChild;
+
+  // Trigger measurement when open/active state changes
+  useEffect(() => {
+    requestMeasure();
+  }, [isOpen, isActive, hasActiveChild, requestMeasure]);
+
+  // Vertical: inline expand/collapse with height animation
+  useEffect(() => {
+    if (orientation !== 'vertical') return;
+    const el = contentRef.current;
+    if (!el) return;
+
+    if (isOpen) {
+      const scrollH = el.scrollHeight;
+      setHeight(scrollH);
+      const timer = setTimeout(() => {
+        setHeight(undefined);
+      }, 130);
+      return () => clearTimeout(timer);
+    } else {
+      setHeight(el.scrollHeight);
+      el.getBoundingClientRect();
+      setHeight(0);
+    }
+  }, [isOpen, orientation]);
+
+  // Horizontal dropdown: close on click outside
+  useEffect(() => {
+    if (orientation !== 'horizontal' || !isOpen) return;
+    const handleClick = (e: MouseEvent) => {
+      if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) {
+        startClose();
+      }
+    };
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [orientation, isOpen]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Horizontal dropdown: viewport collision detection
+  useLayoutEffect(() => {
+    if (orientation !== 'horizontal' || !isOpen) return;
+    const dropdown = dropdownRef.current;
+    if (!dropdown) return;
+    const rect = dropdown.getBoundingClientRect();
+    // Flip to right-aligned if overflowing right edge
+    if (rect.right > window.innerWidth) {
+      dropdown.style.left = 'auto';
+      dropdown.style.right = '0';
+    }
+    // Push up if overflowing bottom edge
+    if (rect.bottom > window.innerHeight) {
+      dropdown.style.top = 'auto';
+      dropdown.style.bottom = '100%';
+      dropdown.style.marginTop = '0';
+      dropdown.style.marginBottom = 'var(--lucent-space-1)';
+    }
+  }, [orientation, isOpen]);
+
+  // Dropdown exit animation state
+  const [animState, setAnimState] = useState<'idle' | 'entering' | 'exiting'>('idle');
+  const [visible, setVisible] = useState(false);
+
+  const startOpen = () => {
+    if (disabled) return;
+    setVisible(true);
+    setAnimState('entering');
+    setIsOpen(true);
+  };
+
+  const startClose = () => {
+    setAnimState('exiting');
+    setTimeout(() => {
+      setIsOpen(false);
+      setVisible(false);
+      setAnimState('idle');
+    }, ANIM_DURATION);
+  };
+
+  const toggle = () => {
+    if (disabled) return;
+    if (orientation === 'horizontal') {
+      if (isOpen) startClose();
+      else startOpen();
+    } else {
+      setIsOpen(!isOpen);
+    }
+  };
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (disabled) return;
+    if (orientation === 'vertical') {
+      if (e.key === 'ArrowRight' && !isOpen) { e.preventDefault(); setIsOpen(true); }
+      if (e.key === 'ArrowLeft' && isOpen) { e.preventDefault(); setIsOpen(false); }
+    } else {
+      if (e.key === 'ArrowDown' && !isOpen) { e.preventDefault(); startOpen(); }
+      if (e.key === 'ArrowUp' && isOpen) { e.preventDefault(); startClose(); }
+    }
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      toggle();
+    }
+    if (e.key === 'Escape' && isOpen) {
+      e.preventDefault();
+      if (orientation === 'horizontal') startClose();
+      else setIsOpen(false);
+    }
+  };
+
+  // Horizontal hover open/close
+  const handleMouseEnter = () => {
+    if (orientation === 'horizontal' && !disabled) {
+      clearTimeout(closeTimer.current);
+      startOpen();
+    }
+  };
+  const handleMouseLeave = () => {
+    if (orientation === 'horizontal') {
+      closeTimer.current = setTimeout(() => startClose(), 150);
+    }
+  };
+
+  if (orientation === 'horizontal') {
+    return (
+      <div
+        ref={wrapperRef}
+        style={{ position: 'relative' }}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+      >
+        <button
+          data-lucent-navitem=""
+          data-hint={showHint || undefined}
+          onClick={(e) => {
+            toggle();
+            onClick?.(e);
+          }}
+          onKeyDown={handleKeyDown}
+          aria-expanded={isOpen}
+          aria-disabled={disabled || undefined}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: tokens.gap,
+            padding: `${tokens.paddingY} ${tokens.paddingX}`,
+            borderRadius: 'var(--lucent-radius-md)',
+            background: 'transparent',
+            color: disabled
+              ? 'var(--lucent-text-disabled)'
+              : showHint
+              ? 'var(--lucent-text-primary)'
+              : 'var(--lucent-text-secondary)',
+            border: 0,
+            borderBottom: showHint
+              ? '2px solid var(--lucent-accent-default)'
+              : '2px solid transparent',
+            fontFamily: 'var(--lucent-font-family-base)',
+            fontSize: tokens.fontSize,
+            fontWeight: showHint ? 'var(--lucent-font-weight-medium)' : 'var(--lucent-font-weight-regular)',
+            cursor: disabled ? 'not-allowed' : 'pointer',
+            transition: 'background var(--lucent-duration-fast) var(--lucent-easing-default), color var(--lucent-duration-fast) var(--lucent-easing-default)',
+            userSelect: 'none',
+            whiteSpace: 'nowrap',
+            outline: 'none',
+            boxSizing: 'border-box',
+            ...style,
+          }}
+        >
+          {icon != null && (
+            <span style={{ display: 'flex', flexShrink: 0, width: tokens.iconWidth, minWidth: 14, minHeight: 14, alignItems: 'center', justifyContent: 'center', color: 'inherit' }}>{icon}</span>
+          )}
+          <span>{children}</span>
+          {badge != null && (
+            <span style={{ display: 'flex', flexShrink: 0 }}>{badge}</span>
+          )}
+        </button>
+
+        {/* Horizontal dropdown */}
+        {visible && (
+          <NavMenuContext.Provider value={{ orientation: 'vertical', depth: 0, inverse, size, hasIcons, parentHasIcon: false, requestMeasure }}>
+            <div
+              ref={dropdownRef}
+              style={{
+                position: 'absolute',
+                top: '100%',
+                left: 0,
+                marginTop: 'var(--lucent-space-1)',
+                minWidth: 180,
+                background: 'var(--lucent-surface)',
+                border: '1px solid var(--lucent-border-default)',
+                borderRadius: 'var(--lucent-radius-lg)',
+                boxShadow: 'var(--lucent-shadow-lg)',
+                padding: 'var(--lucent-space-1)',
+                zIndex: 100,
+                animation: animState === 'exiting'
+                  ? `lucent-navmenu-dropdown-out ${ANIM_DURATION}ms var(--lucent-easing-default) forwards`
+                  : `lucent-navmenu-dropdown-in ${ANIM_DURATION}ms var(--lucent-easing-default) forwards`,
+              }}
+            >
+              {subMenu}
+            </div>
+          </NavMenuContext.Provider>
+        )}
+      </div>
+    );
+  }
+
+  // Vertical orientation: inline expand/collapse
+  return (
+    <div style={{ position: 'relative', zIndex: 1 }}>
+      <button
+        data-lucent-navitem=""
+        data-active={selfActive || undefined}
+        data-active-parent={collapsedWithActiveChild || undefined}
+        data-hint={(!selfActive && !collapsedWithActiveChild && showHint) || undefined}
+        onClick={(e) => {
+          toggle();
+          onClick?.(e);
+        }}
+        onKeyDown={handleKeyDown}
+        aria-expanded={isOpen}
+        aria-disabled={disabled || undefined}
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: tokens.gap,
+          width: '100%',
+          padding: `${tokens.paddingY} ${tokens.paddingX} ${tokens.paddingY} ${icon != null ? 'var(--lucent-space-2)' : 'var(--lucent-space-4)'}`,
+          borderRadius: 'var(--lucent-radius-md)',
+          background: 'transparent',
+          color: disabled
+            ? 'var(--lucent-text-disabled)'
+            : selfActive
+            ? (inverse ? 'var(--lucent-text-primary)' : 'var(--lucent-text-on-accent)')
+            : collapsedWithActiveChild
+            ? 'var(--lucent-text-primary)'
+            : showHint
+            ? 'var(--lucent-text-primary)'
+            : 'var(--lucent-text-secondary)',
+          border: 0,
+          boxShadow: 'none',
+          fontFamily: 'var(--lucent-font-family-base)',
+          fontSize: tokens.fontSize,
+          fontWeight: showHint ? 'var(--lucent-font-weight-medium)' : 'var(--lucent-font-weight-regular)',
+          textAlign: 'left',
+          textDecoration: 'none',
+          cursor: disabled ? 'not-allowed' : 'pointer',
+          transition: 'background var(--lucent-duration-fast) var(--lucent-easing-default), color var(--lucent-duration-fast) var(--lucent-easing-default)',
+          userSelect: 'none',
+          boxSizing: 'border-box',
+          outline: 'none',
+          ...style,
+        }}
+      >
+        {icon != null && (
+          <span style={{ display: 'flex', flexShrink: 0, width: tokens.iconWidth, minWidth: 14, minHeight: 14, alignItems: 'center', justifyContent: 'center', color: 'inherit' }}>{icon}</span>
+        )}
+        <span style={{ flex: 1 }}>{children}</span>
+        {badge != null && (
+          <span style={{ display: 'flex', flexShrink: 0 }}>{badge}</span>
+        )}
+      </button>
+
+      {/* Collapsible children */}
+      <div
+        ref={contentRef}
+        aria-hidden={!isOpen}
+        style={{
+          overflow: 'hidden',
+          height: height !== undefined ? height : 'auto',
+          transition: 'height 120ms var(--lucent-easing-default)',
+        }}
+      >
+        <NavMenuContext.Provider value={{ orientation, depth: depth + 1, inverse, size, hasIcons, parentHasIcon: icon != null, requestMeasure }}>
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              gap: tokens.itemGap,
+              padding: `var(--lucent-space-1) 0`,
+              marginLeft: icon != null
+                ? `calc(${tokens.iconWidth} + ${tokens.gap})`
+                : 'var(--lucent-space-3)',
+              animation: isOpen ? 'lucent-navmenu-open 200ms var(--lucent-easing-default) forwards' : undefined,
+            }}
+          >
+            {subMenu}
+          </div>
+        </NavMenuContext.Provider>
+      </div>
+    </div>
+  );
+}
+
+/* ─── useHasActiveChild ─────────────────────────────────────────────────────── */
+
+/** Walks the ReactNode tree to detect if any NavMenuItem has isActive=true. */
+function useHasActiveChild(subMenu: ReactNode): boolean {
+  return checkActiveChild(subMenu);
+}
+
+function checkActiveChild(node: ReactNode): boolean {
+  if (node == null) return false;
+  if (Array.isArray(node)) return node.some(checkActiveChild);
+  if (typeof node === 'object' && 'props' in node) {
+    const el = node as React.ReactElement<NavMenuItemProps & { children?: ReactNode }>;
+    if (el.props.isActive) return true;
+    if (el.props.children) return checkActiveChild(el.props.children);
+  }
+  return false;
+}
+
+/* ─── NavMenu.Sub ───────────────────────────────────────────────────────────── */
+
+export interface NavMenuSubProps {
+  children: ReactNode;
+}
+
+export function NavMenuSub({ children }: NavMenuSubProps) {
+  // Marker component — children rendered by NavMenuParentItem.
+  return <>{children}</>;
+}
+
+/* ─── NavMenu.Group ─────────────────────────────────────────────────────────── */
+
+export interface NavMenuGroupProps {
+  children: ReactNode;
+  /** Section header label. */
+  label?: ReactNode;
+  /** Whether this group starts open. Only applies to vertical orientation. */
+  defaultOpen?: boolean;
+  /** Controlled open state. */
+  open?: boolean;
+  /** Callback when the group open state changes. */
+  onOpenChange?: (open: boolean) => void;
+  /** Whether the group is collapsible. Defaults to `true` when a label is provided. */
+  collapsible?: boolean;
+  style?: CSSProperties;
+}
+
+export function NavMenuGroup({
+  children,
+  label,
+  defaultOpen = true,
+  open,
+  onOpenChange,
+  collapsible: collapsibleProp,
+  style,
+}: NavMenuGroupProps) {
+  const { orientation, inverse, size, hasIcons } = useContext(NavMenuContext);
+  const tokens = SIZE_TOKENS[size];
+  const isCollapsible = collapsibleProp ?? (label != null);
+  const headerInset = hasIcons ? 'var(--lucent-space-2)' : 'var(--lucent-space-4)';
+
+  // In horizontal mode, groups just render children inline
+  if (orientation === 'horizontal') {
+    return <>{children}</>;
+  }
+
+  const isControlled = open !== undefined;
+  const [internalOpen, setInternalOpen] = useState(defaultOpen);
+  const isOpen = isControlled ? open! : internalOpen;
+
+  const contentRef = useRef<HTMLDivElement>(null);
+  const [height, setHeight] = useState<number | undefined>(isOpen ? undefined : 0);
+
+  useEffect(() => {
+    if (!isCollapsible) return;
+    const el = contentRef.current;
+    if (!el) return;
+
+    if (isOpen) {
+      const scrollH = el.scrollHeight;
+      setHeight(scrollH);
+      const timer = setTimeout(() => {
+        setHeight(undefined);
+      }, 130);
+      return () => clearTimeout(timer);
+    } else {
+      setHeight(el.scrollHeight);
+      el.getBoundingClientRect();
+      setHeight(0);
+    }
+  }, [isOpen, isCollapsible]);
+
+  const toggle = useCallback(() => {
+    const next = !isOpen;
+    if (!isControlled) setInternalOpen(next);
+    onOpenChange?.(next);
+  }, [isOpen, isControlled, onOpenChange]);
+
+  if (!label) {
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: tokens.itemGap, ...style }}>
+        {children}
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', marginTop: 'var(--lucent-space-3)', ...style }}>
+      {/* Group header */}
+      {isCollapsible ? (
+        <button
+          onClick={toggle}
+          aria-expanded={isOpen}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            width: '100%',
+            padding: `var(--lucent-space-1) var(--lucent-space-3) var(--lucent-space-1) ${headerInset}`,
+            background: 'none',
+            border: 0,
+            cursor: 'pointer',
+            outline: 'none',
+            fontFamily: 'var(--lucent-font-family-base)',
+            fontSize: 'var(--lucent-font-size-xs)',
+            fontWeight: 'var(--lucent-font-weight-semibold)',
+            color: 'var(--lucent-text-secondary)',
+            letterSpacing: '0.05em',
+            textTransform: 'uppercase',
+            textAlign: 'left',
+            userSelect: 'none',
+            marginBottom: isOpen ? 'var(--lucent-space-1)' : '0',
+            transition: 'margin-bottom 200ms var(--lucent-easing-default)',
+          }}
+        >
+          <span>{label}</span>
+          <NavMenuChevron open={isOpen} size={12} />
+        </button>
+      ) : (
+        <div
+          style={{
+            padding: `var(--lucent-space-1) var(--lucent-space-3) var(--lucent-space-1) ${headerInset}`,
+            fontFamily: 'var(--lucent-font-family-base)',
+            fontSize: 'var(--lucent-font-size-xs)',
+            fontWeight: 'var(--lucent-font-weight-semibold)',
+            color: 'var(--lucent-text-secondary)',
+            letterSpacing: '0.05em',
+            textTransform: 'uppercase',
+            userSelect: 'none',
+            marginBottom: 'var(--lucent-space-1)',
+          }}
+        >
+          {label}
+        </div>
+      )}
+
+      {/* Group children */}
+      {isCollapsible ? (
+        <div
+          ref={contentRef}
+          aria-hidden={!isOpen}
+          style={{
+            overflow: 'hidden',
+            height: height !== undefined ? height : 'auto',
+            transition: 'height 120ms var(--lucent-easing-default)',
+          }}
+        >
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              gap: tokens.itemGap,
+            }}
+          >
+            {children}
+          </div>
+        </div>
+      ) : (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: tokens.itemGap }}>
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ─── NavMenu.Separator ─────────────────────────────────────────────────────── */
+
+export interface NavMenuSeparatorProps {
+  style?: CSSProperties;
+}
+
+export function NavMenuSeparator({ style }: NavMenuSeparatorProps) {
+  const { orientation } = useContext(NavMenuContext);
+
+  return (
+    <div
+      role="separator"
+      style={{
+        ...(orientation === 'vertical'
+          ? {
+              height: 1,
+              margin: 'var(--lucent-space-2) var(--lucent-space-4)',
+            }
+          : {
+              width: 1,
+              alignSelf: 'stretch',
+              margin: 'var(--lucent-space-1) var(--lucent-space-1)',
+            }),
+        background: 'var(--lucent-border-default)',
+        flexShrink: 0,
+        ...style,
+      }}
+    />
+  );
+}
+
+/* ─── Chevron helper ────────────────────────────────────────────────────────── */
+
+function NavMenuChevron({ open, size = 14 }: { open: boolean; size?: number }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+      style={{
+        flexShrink: 0,
+        color: 'var(--lucent-text-secondary)',
+        transform: open ? 'rotate(180deg)' : 'rotate(0deg)',
+        transition: 'transform 200ms var(--lucent-easing-default)',
+      }}
+    >
+      <polyline points="6 9 12 15 18 9" />
+    </svg>
+  );
+}
+
+/* ─── Compound export ───────────────────────────────────────────────────────── */
+
+NavMenu.Item = NavMenuItem;
+NavMenu.Group = NavMenuGroup;
+NavMenu.Sub = NavMenuSub;
+NavMenu.Separator = NavMenuSeparator;

--- a/src/components/molecules/NavMenu/index.ts
+++ b/src/components/molecules/NavMenu/index.ts
@@ -1,0 +1,1 @@
+export * from './NavMenu.js';

--- a/src/components/molecules/index.ts
+++ b/src/components/molecules/index.ts
@@ -17,3 +17,4 @@ export * from './FileUpload/index.js';
 export * from './Timeline/index.js';
 export * from './Menu/index.js';
 export * from './Toast/index.js';
+export * from './NavMenu/index.js';


### PR DESCRIPTION
## Summary

- **NavMenu molecule** — hierarchical navigation for sidebar and top-bar layouts with a DOM-driven sliding highlight pill (MutationObserver + ResizeObserver + rAF, zero timeout coordination)
- **Self-active parent mode** — `isActive` on a parent with no active children highlights the parent itself, useful for section-level pages that represent all children
- **CSS hover states** — injected `[data-lucent-navitem]` rule with `:not()` exclusions, 5% translucent tint that never conflicts with the accent pill
- **Inverse mode** — surface background with accent right-border (`inset -3px`) and elevation shadow
- **`hasIcons` prop** — controls left-padding alignment for items, group headers, and sub-menu children via `parentHasIcon` context inheritance
- **Dev preview** — grouped nav sidebar with size/inverse/icons toggles and `selectAll` mode for Text & Labels group

## Details

### Highlight architecture
The root NavMenu owns all measurement logic — queries the DOM for `[data-active="true"]` / `[data-active-parent="true"]`, positions a single always-in-DOM pill via direct style mutation. `aria-hidden` ancestry detects collapsed items (replaces unreliable `offsetHeight` checks). MutationObserver + ResizeObserver auto-trigger re-measurement.

### Three highlight states
1. **Child active** — full accent pill on the active child item
2. **Collapsed with active child** — lighter pill (12% accent tint) on the parent button, text stays `text-primary`
3. **Self-active parent** — full accent pill on the parent itself (no child selected)

### Padding alignment
- `hasIcons={true}` → `space-2` left padding on items/headers (aligns with icon start)
- `hasIcons={false}` → `space-4` left padding (standard text layout)
- Sub-menu children inherit `parentHasIcon` via context for consistent text alignment with parent label

## Test plan
- [ ] Click between sibling items → highlight slides
- [ ] Expand parent → highlight appears on active child
- [ ] Collapse parent with active child → highlight slides to parent (lighter style)
- [ ] Re-expand → highlight slides back to child
- [ ] Self-active parent: click "Text & Labels" → highlight on parent, sub-nav shows children with none selected
- [ ] Click a specific child → highlight moves to child
- [ ] Toggle inverse → right-border accent style with surface bg and shadow
- [ ] Toggle icons → padding alignment adjusts for items, headers, sub-menu children
- [ ] Switch size (SM/MD/LG) → highlight repositions
- [ ] Hover non-active items → subtle 5% tint, clears on leave
- [ ] Hover active/disabled items → no hover effect
- [ ] Window resize → highlight repositions

🤖 Generated with [Claude Code](https://claude.com/claude-code)