### PR TITLE
feat: add Product/Item Card pattern

### DIFF
--- a/dev/ComponentPreview.tsx
+++ b/dev/ComponentPreview.tsx
@@ -217,7 +217,7 @@ function Inner({
     navigation:  { label: 'Navigation',         tier: 'molecule', items: ['Breadcrumb', 'Tabs', 'NavLink', 'NavMenu', 'PageLayout', 'Stepper'] },
     data:        { label: 'Data & Tables',      tier: 'molecule', items: ['DataTable', 'Timeline'] },
     overlays:    { label: 'Overlays & Menus',   tier: 'molecule', items: ['Menu', 'CommandPalette', 'Toast'] },
-    'r-cards':   { label: 'Cards',              tier: 'pattern', items: ['ProfileCard', 'CollapsibleCard', 'EmptyStateCard'] },
+    'r-cards':   { label: 'Cards',              tier: 'pattern', items: ['ProfileCard', 'ProductItemCard', 'CollapsibleCard', 'EmptyStateCard'] },
     'r-layouts': { label: 'Layouts',            tier: 'pattern', items: ['SettingsPanel', 'FormLayout', 'StatsRow', 'ActionBar'] },
     'r-filters': { label: 'Filters',           tier: 'pattern', items: ['SearchFilterBar'] },
     'c-all':     { label: 'All Compositions',   tier: 'composition', items: ['GoldenProfileCard', 'GoldenPreferencesCard', 'GoldenPricingTable', 'GoldenNotificationFeed', 'GoldenOnboardingFlow', 'GoldenDashboardHeader'] },
@@ -2990,6 +2990,97 @@ function Inner({
               description="We couldn't load your data. Please try again."
               action={<Button variant="outline" size="sm">Retry</Button>}
             />
+          </Card>
+        </Row>
+      </Section>
+
+      <Section title="ProductItemCard" tokens={tokens} hidden={!showSection('ProductItemCard')}>
+        <Row label="Product card (default)" tokens={tokens}>
+          <Card
+            variant="elevated"
+            padding="lg"
+            style={{ width: 320 }}
+            media={
+              <div style={{ height: 180, background: `linear-gradient(135deg, ${tokens.surfaceRaised} 0%, color-mix(in srgb, ${tokens.accentDefault} 12%, ${tokens.surfaceRaised}) 100%)`, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                <Icon size="xl" color={tokens.textSecondary}>
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M3 18v-6a9 9 0 0118 0v6" />
+                    <path d="M21 19a2 2 0 01-2 2h-1a2 2 0 01-2-2v-3a2 2 0 012-2h3zM3 19a2 2 0 002 2h1a2 2 0 002-2v-3a2 2 0 00-2-2H3z" />
+                  </svg>
+                </Icon>
+              </div>
+            }
+          >
+            <StackAtom gap="4">
+              <StackAtom gap="1">
+                <Text size="md" weight="semibold">Wireless Headphones</Text>
+                <Text size="sm" color="secondary">Active noise cancelling, 40hr battery</Text>
+              </StackAtom>
+              <RowAtom gap="2" wrap>
+                <Chip variant="neutral" size="sm">Audio</Chip>
+                <Chip variant="neutral" size="sm">Bluetooth</Chip>
+                <Chip variant="neutral" size="sm">ANC</Chip>
+              </RowAtom>
+              <RowAtom gap="4" justify="between" align="baseline">
+                <Text size="lg" weight="bold" family="display">$249.00</Text>
+                <Text size="xs" color="secondary">Free shipping</Text>
+              </RowAtom>
+              <Button variant="primary" style={{ width: '100%' }}>Add to Cart</Button>
+            </StackAtom>
+          </Card>
+        </Row>
+        <Row label="Article card variant" tokens={tokens}>
+          <Card variant="outline" padding="lg" hoverable style={{ width: 340 }}>
+            <StackAtom gap="4">
+              <RowAtom gap="3" align="start">
+                <Icon size="lg" color="var(--lucent-text-secondary)">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z" />
+                    <polyline points="14 2 14 8 20 8" />
+                    <line x1={16} y1={13} x2={8} y2={13} />
+                    <line x1={16} y1={17} x2={8} y2={17} />
+                    <polyline points="10 9 9 9 8 9" />
+                  </svg>
+                </Icon>
+                <StackAtom gap="1" style={{ flex: 1 }}>
+                  <Text size="md" weight="semibold">Design Tokens at Scale</Text>
+                  <Text size="xs" color="secondary">Published Mar 15, 2026</Text>
+                </StackAtom>
+              </RowAtom>
+              <Text size="sm" color="secondary">
+                How we unified spacing, color, and typography across 12 product surfaces using a single token system.
+              </Text>
+              <RowAtom gap="2" wrap>
+                <Chip variant="neutral" size="sm">Design Systems</Chip>
+                <Chip variant="neutral" size="sm">Tokens</Chip>
+              </RowAtom>
+              <RowAtom gap="4" justify="between" align="center">
+                <Text size="xs" color="secondary">8 min read</Text>
+                <Button variant="ghost" size="sm">Read more</Button>
+              </RowAtom>
+            </StackAtom>
+          </Card>
+        </Row>
+        <Row label="Team member card variant" tokens={tokens}>
+          <Card variant="filled" padding="lg" style={{ width: 280 }}>
+            <StackAtom gap="4">
+              <StackAtom gap="3" align="center">
+                <Avatar alt="Alex Chen" size="lg" />
+                <StackAtom gap="0" align="center">
+                  <Text size="md" weight="semibold">Alex Chen</Text>
+                  <Text size="sm" color="secondary">Engineering Lead</Text>
+                </StackAtom>
+              </StackAtom>
+              <RowAtom gap="2" wrap justify="center">
+                <Chip variant="neutral" size="sm">React</Chip>
+                <Chip variant="neutral" size="sm">Go</Chip>
+                <Chip variant="neutral" size="sm">Platform</Chip>
+              </RowAtom>
+              <RowAtom gap="3">
+                <Button variant="outline" style={{ flex: 1 }} size="sm">Profile</Button>
+                <Button variant="primary" style={{ flex: 1 }} size="sm">Message</Button>
+              </RowAtom>
+            </StackAtom>
           </Card>
         </Row>
       </Section>

--- a/server/pattern-registry.ts
+++ b/server/pattern-registry.ts
@@ -8,6 +8,7 @@ import { PATTERN as FormLayout } from '../src/manifest/patterns/form-layout.patt
 import { PATTERN as EmptyStateCard } from '../src/manifest/patterns/empty-state-card.pattern.js';
 import { PATTERN as CollapsibleCard } from '../src/manifest/patterns/collapsible-card.pattern.js';
 import { PATTERN as SearchFilterBar } from '../src/manifest/patterns/search-filter-bar.pattern.js';
+import { PATTERN as ProductItemCard } from '../src/manifest/patterns/product-item-card.pattern.js';
 
 export const ALL_PATTERNS: CompositionPattern[] = [
   ProfileCard,
@@ -18,4 +19,5 @@ export const ALL_PATTERNS: CompositionPattern[] = [
   EmptyStateCard,
   CollapsibleCard,
   SearchFilterBar,
+  ProductItemCard,
 ];

--- a/src/manifest/patterns/product-item-card.pattern.ts
+++ b/src/manifest/patterns/product-item-card.pattern.ts
@@ -1,0 +1,117 @@
+import type { CompositionPattern } from '../types.js';
+
+export const PATTERN: CompositionPattern = {
+  id: 'product-item-card',
+  name: 'Product/Item Card',
+  description: 'Versatile content card with media slot, title, tags, metadata, and CTA. Reusable for products, articles, team members, or any entity list.',
+  category: 'card',
+  components: ['card', 'avatar', 'icon', 'text', 'chip', 'button', 'stack', 'row'],
+
+  structure: `
+Card (elevated, padding="lg", media=<img>)
+└── Stack gap="4"
+    ├── Stack gap="1"
+    │   ├── Text (md, semibold)        ← title
+    │   └── Text (sm, secondary)       ← subtitle
+    ├── Row gap="2" wrap
+    │   └── Chip[] (neutral, sm)       ← tags / categories
+    ├── Row gap="4" justify="between" align="baseline"
+    │   ├── Text (lg, bold, display)   ← price / key metric
+    │   └── Text (xs, secondary)       ← secondary info
+    └── Button (primary, full width)   ← CTA
+  `.trim(),
+
+  code: `<Card
+  variant="elevated"
+  padding="lg"
+  style={{ width: 320 }}
+  media={<img src="/products/headphones.jpg" alt="Wireless Headphones" style={{ width: '100%', height: 180, objectFit: 'cover', display: 'block' }} />}
+>
+  <Stack gap="4">
+    <Stack gap="1">
+      <Text size="md" weight="semibold">Wireless Headphones</Text>
+      <Text size="sm" color="secondary">Active noise cancelling, 40hr battery</Text>
+    </Stack>
+    <Row gap="2" wrap>
+      <Chip variant="neutral" size="sm">Audio</Chip>
+      <Chip variant="neutral" size="sm">Bluetooth</Chip>
+      <Chip variant="neutral" size="sm">ANC</Chip>
+    </Row>
+    <Row gap="4" justify="between" align="baseline">
+      <Text size="lg" weight="bold" family="display">$249.00</Text>
+      <Text size="xs" color="secondary">Free shipping</Text>
+    </Row>
+    <Button variant="primary" style={{ width: '100%' }}>Add to Cart</Button>
+  </Stack>
+</Card>`,
+
+  variants: [
+    {
+      title: 'Article card',
+      code: `<Card variant="outline" padding="lg" hoverable style={{ width: 340 }}>
+  <Stack gap="4">
+    <Row gap="3" align="start">
+      <Icon size={20} color="var(--lucent-text-secondary)">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round">
+          <path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z" />
+          <polyline points="14 2 14 8 20 8" />
+          <line x1={16} y1={13} x2={8} y2={13} />
+          <line x1={16} y1={17} x2={8} y2={17} />
+        </svg>
+      </Icon>
+      <Stack gap="1" style={{ flex: 1 }}>
+        <Text size="md" weight="semibold">Design Tokens at Scale</Text>
+        <Text size="xs" color="secondary">Published Mar 15, 2026</Text>
+      </Stack>
+    </Row>
+    <Text size="sm" color="secondary">
+      How we unified spacing, color, and typography across 12 product surfaces using a single token system.
+    </Text>
+    <Row gap="2" wrap>
+      <Chip variant="neutral" size="sm">Design Systems</Chip>
+      <Chip variant="neutral" size="sm">Tokens</Chip>
+    </Row>
+    <Row gap="4" justify="between" align="center">
+      <Text size="xs" color="secondary">8 min read</Text>
+      <Button variant="ghost" size="sm">Read more</Button>
+    </Row>
+  </Stack>
+</Card>`,
+    },
+    {
+      title: 'Team member card',
+      code: `<Card variant="filled" padding="lg" style={{ width: 280 }}>
+  <Stack gap="4">
+    <Stack gap="3" align="center">
+      <Avatar src="/avatars/alex.jpg" alt="Alex Chen" size="lg" />
+      <Stack gap="0" align="center">
+        <Text size="md" weight="semibold">Alex Chen</Text>
+        <Text size="sm" color="secondary">Engineering Lead</Text>
+      </Stack>
+    </Stack>
+    <Row gap="2" wrap justify="center">
+      <Chip variant="neutral" size="sm">React</Chip>
+      <Chip variant="neutral" size="sm">Go</Chip>
+      <Chip variant="neutral" size="sm">Platform</Chip>
+    </Row>
+    <Row gap="3">
+      <Button variant="outline" style={{ flex: 1 }} size="sm">Profile</Button>
+      <Button variant="primary" style={{ flex: 1 }} size="sm">Message</Button>
+    </Row>
+  </Stack>
+</Card>`,
+    },
+  ],
+
+  designNotes:
+    'The default product card uses the Card media slot for a full-bleed hero image ' +
+    'at the top, keeping the content area clean with just title, tags, price, and CTA. ' +
+    'Tags use neutral Chips at sm size for low visual weight — they inform without ' +
+    'competing with the title. The price/metric row uses justify="between" with ' +
+    'align="baseline" to anchor the large display-font value and the secondary caption ' +
+    'to the same text baseline. A full-width primary Button as the sole CTA creates a ' +
+    'clear action target. The article variant swaps the media slot for an inline Icon + ' +
+    'text header and replaces the price row with read-time + ghost button, keeping the ' +
+    'same vertical rhythm. The team member variant centers the content for a profile-style ' +
+    'layout and uses a dual-button footer with flex: 1 for equal width.',
+};


### PR DESCRIPTION
## Summary
- Adds `product-item-card` pattern in `src/manifest/patterns/product-item-card.pattern.ts`
- **Default**: media card with full-bleed hero image, title/subtitle, neutral tag chips, price row, full-width CTA
- **Article variant**: icon + text header, description paragraph, read-time + ghost button footer
- **Team member variant**: centered avatar layout, skill chips with borders, dual action buttons
- Registered in `server/pattern-registry.ts` — available via `get_composition_pattern` and `search_components`
- Added to dev ComponentPreview under Patterns > Cards with all 3 variants

Closes #110

## Test plan
- [ ] `pnpm build:server` compiles cleanly
- [ ] `pnpm dev` — ProductItemCard section renders all 3 variants without errors
- [ ] MCP: `get_composition_pattern` with `name: "product-item-card"` returns pattern with 2 variants
- [ ] MCP: `search_components` with `query: "product card"` includes the pattern in results

🤖 Generated with [Claude Code](https://claude.com/claude-code)