### PR TITLE
feat: add Announcement Card pattern

### DIFF
--- a/dev/ComponentPreview.tsx
+++ b/dev/ComponentPreview.tsx
@@ -217,7 +217,7 @@ function Inner({
     navigation:  { label: 'Navigation',         tier: 'molecule', items: ['Breadcrumb', 'Tabs', 'NavLink', 'NavMenu', 'PageLayout', 'Stepper'] },
     data:        { label: 'Data & Tables',      tier: 'molecule', items: ['DataTable', 'Timeline'] },
     overlays:    { label: 'Overlays & Menus',   tier: 'molecule', items: ['Menu', 'CommandPalette', 'Toast'] },
-    'r-cards':   { label: 'Cards',              tier: 'pattern', items: ['ProfileCard', 'ProductItemCard', 'CollapsibleCard', 'EmptyStateCard'] },
+    'r-cards':   { label: 'Cards',              tier: 'pattern', items: ['ProfileCard', 'ProductItemCard', 'AnnouncementCard', 'CollapsibleCard', 'EmptyStateCard'] },
     'r-layouts': { label: 'Layouts',            tier: 'pattern', items: ['SettingsPanel', 'FormLayout', 'StatsRow', 'ActionBar'] },
     'r-filters': { label: 'Filters',           tier: 'pattern', items: ['SearchFilterBar'] },
     'c-all':     { label: 'All Compositions',   tier: 'composition', items: ['GoldenProfileCard', 'GoldenPreferencesCard', 'GoldenPricingTable', 'GoldenNotificationFeed', 'GoldenOnboardingFlow', 'GoldenDashboardHeader'] },
@@ -3081,6 +3081,100 @@ function Inner({
                 <Button variant="primary" style={{ flex: 1 }} size="sm">Message</Button>
               </RowAtom>
             </StackAtom>
+          </Card>
+        </Row>
+      </Section>
+
+      <Section title="AnnouncementCard" tokens={tokens} hidden={!showSection('AnnouncementCard')}>
+        <Row label="Feature announcement with media" tokens={tokens}>
+          <Card
+            variant="elevated"
+            padding="lg"
+            style={{ width: 380 }}
+            media={
+              <div style={{ height: 160, background: `linear-gradient(135deg, color-mix(in srgb, ${tokens.accentDefault} 15%, ${tokens.surfaceRaised}) 0%, color-mix(in srgb, ${tokens.accentDefault} 5%, ${tokens.surfaceRaised}) 100%)`, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                <Icon size="xl" color={tokens.accentDefault}>
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M3 3v18h18" />
+                    <path d="M7 16l4-8 4 4 4-6" />
+                  </svg>
+                </Icon>
+              </div>
+            }
+          >
+            <StackAtom gap="4">
+              <RowAtom gap="2">
+                <Chip variant="accent" size="sm">New Feature</Chip>
+              </RowAtom>
+              <StackAtom gap="1">
+                <Text size="md" weight="semibold">Redesigned Analytics Dashboard</Text>
+                <Text size="sm" color="secondary">Track key metrics at a glance with our new real-time dashboard. Includes custom date ranges, export to CSV, and team sharing.</Text>
+              </StackAtom>
+              <RowAtom gap="2">
+                <Button variant="primary" size="sm">Try it now</Button>
+                <Button variant="ghost" size="sm">Learn more</Button>
+              </RowAtom>
+            </StackAtom>
+          </Card>
+        </Row>
+        <Row label="System notice (no media)" tokens={tokens}>
+          <Card variant="outline" padding="md" style={{ width: 400, borderColor: 'var(--lucent-warning-default)' }}>
+            <RowAtom gap="3" align="start">
+              <Icon size="lg" color="var(--lucent-warning-text)">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" />
+                  <line x1={12} y1={9} x2={12} y2={13} />
+                  <line x1={12} y1={17} x2={12.01} y2={17} />
+                </svg>
+              </Icon>
+              <StackAtom gap="2" style={{ flex: 1 }}>
+                <Text size="sm" weight="semibold">Storage almost full</Text>
+                <Text size="sm" color="secondary">You've used 92% of your storage. Upgrade your plan or delete unused files to free up space.</Text>
+                <RowAtom gap="2">
+                  <Button variant="primary" size="sm">Upgrade plan</Button>
+                  <Button variant="ghost" size="sm">Manage storage</Button>
+                </RowAtom>
+              </StackAtom>
+            </RowAtom>
+          </Card>
+        </Row>
+        <Row label="Promotional banner with thumbnail" tokens={tokens}>
+          <Card variant="filled" padding="md" hoverable style={{ width: 380 }}>
+            <RowAtom gap="5" align="center">
+              <div style={{ width: 80, height: 80, borderRadius: 'var(--lucent-radius-lg)', overflow: 'hidden', flexShrink: 0, background: `linear-gradient(135deg, color-mix(in srgb, var(--lucent-success-default) 20%, ${tokens.surfaceRaised}) 0%, ${tokens.surfaceRaised} 100%)`, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                <Icon size="lg" color="var(--lucent-success-text)">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M20.59 13.41l-7.17 7.17a2 2 0 01-2.83 0L2 12V2h10l8.59 8.59a2 2 0 010 2.82z" />
+                    <line x1={7} y1={7} x2={7.01} y2={7} />
+                  </svg>
+                </Icon>
+              </div>
+              <StackAtom gap="2" style={{ flex: 1 }}>
+                <RowAtom gap="2" align="center">
+                  <Text size="md" weight="semibold">Spring Sale</Text>
+                  <Chip variant="success" size="sm">-30%</Chip>
+                </RowAtom>
+                <Text size="sm" color="secondary">All Pro plans are 30% off through April. Upgrade now and lock in the price for a year.</Text>
+                <Button variant="primary" size="sm" style={{ alignSelf: 'flex-start' }}>Claim offer</Button>
+              </StackAtom>
+            </RowAtom>
+          </Card>
+        </Row>
+        <Row label="Success confirmation" tokens={tokens}>
+          <Card variant="outline" padding="md" style={{ width: 400, borderColor: 'var(--lucent-success-default)' }}>
+            <RowAtom gap="3" align="start">
+              <Icon size="lg" color="var(--lucent-success-text)">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M22 11.08V12a10 10 0 11-5.93-9.14" />
+                  <polyline points="22 4 12 14.01 9 11.01" />
+                </svg>
+              </Icon>
+              <StackAtom gap="1" style={{ flex: 1 }}>
+                <Text size="sm" weight="semibold">Payment received</Text>
+                <Text size="sm" color="secondary">Your invoice #1042 for $2,400.00 has been paid successfully.</Text>
+              </StackAtom>
+              <Button variant="ghost" size="sm">Dismiss</Button>
+            </RowAtom>
           </Card>
         </Row>
       </Section>

--- a/server/pattern-registry.ts
+++ b/server/pattern-registry.ts
@@ -9,6 +9,7 @@ import { PATTERN as EmptyStateCard } from '../src/manifest/patterns/empty-state-
 import { PATTERN as CollapsibleCard } from '../src/manifest/patterns/collapsible-card.pattern.js';
 import { PATTERN as SearchFilterBar } from '../src/manifest/patterns/search-filter-bar.pattern.js';
 import { PATTERN as ProductItemCard } from '../src/manifest/patterns/product-item-card.pattern.js';
+import { PATTERN as NotificationCard } from '../src/manifest/patterns/notification-card.pattern.js';
 
 export const ALL_PATTERNS: CompositionPattern[] = [
   ProfileCard,
@@ -20,4 +21,5 @@ export const ALL_PATTERNS: CompositionPattern[] = [
   CollapsibleCard,
   SearchFilterBar,
   ProductItemCard,
+  NotificationCard,
 ];

--- a/src/manifest/patterns/notification-card.pattern.ts
+++ b/src/manifest/patterns/notification-card.pattern.ts
@@ -1,0 +1,115 @@
+import type { CompositionPattern } from '../types.js';
+
+export const PATTERN: CompositionPattern = {
+  id: 'announcement-card',
+  name: 'Announcement Card',
+  description: 'Rich announcement card with optional media slot, status icon, title, message, and action buttons. For in-page announcements, feature launches, promotions, or system notices.',
+  category: 'card',
+  components: ['card', 'icon', 'text', 'button', 'chip', 'stack', 'row'],
+
+  structure: `
+Card (elevated, padding="lg", media=<img>)
+└── Stack gap="4"
+    ├── Row gap="2" wrap                       ← optional badge row
+    │   └── Chip (accent/success, sm)          ← category / "New"
+    ├── Stack gap="1"
+    │   ├── Text (md, semibold)                ← title
+    │   └── Text (sm, secondary)               ← message body
+    └── Row gap="2"
+        ├── Button (primary, sm)               ← action
+        └── Button (ghost, sm)                 ← dismiss
+  `.trim(),
+
+  code: `<Card
+  variant="elevated"
+  padding="lg"
+  style={{ width: 380 }}
+  media={<img src="/announcements/feature-launch.jpg" alt="New dashboard" style={{ width: '100%', height: 160, objectFit: 'cover', display: 'block' }} />}
+>
+  <Stack gap="4">
+    <Row gap="2">
+      <Chip variant="accent" size="sm">New Feature</Chip>
+    </Row>
+    <Stack gap="1">
+      <Text size="md" weight="semibold">Redesigned Analytics Dashboard</Text>
+      <Text size="sm" color="secondary">Track key metrics at a glance with our new real-time dashboard. Includes custom date ranges, export to CSV, and team sharing.</Text>
+    </Stack>
+    <Row gap="2">
+      <Button variant="primary" size="sm">Try it now</Button>
+      <Button variant="ghost" size="sm">Learn more</Button>
+    </Row>
+  </Stack>
+</Card>`,
+
+  variants: [
+    {
+      title: 'System notice (no media, with status icon)',
+      code: `<Card variant="outline" padding="md" style={{ width: 400 }}>
+  <Row gap="3" align="start">
+    <Icon size="lg" color="var(--lucent-warning-text)">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round">
+        <path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" />
+        <line x1={12} y1={9} x2={12} y2={13} />
+        <line x1={12} y1={17} x2={12.01} y2={17} />
+      </svg>
+    </Icon>
+    <Stack gap="2" style={{ flex: 1 }}>
+      <Text size="sm" weight="semibold">Storage almost full</Text>
+      <Text size="sm" color="secondary">You've used 92% of your storage. Upgrade your plan or delete unused files to free up space.</Text>
+      <Row gap="2">
+        <Button variant="primary" size="sm">Upgrade plan</Button>
+        <Button variant="ghost" size="sm">Manage storage</Button>
+      </Row>
+    </Stack>
+  </Row>
+</Card>`,
+    },
+    {
+      title: 'Promotional banner with media',
+      code: `<Card variant="filled" padding="md" hoverable style={{ width: 380 }}>
+  <Row gap="5" align="center">
+    <div style={{ width: 80, height: 80, borderRadius: 'var(--lucent-radius-lg)', overflow: 'hidden', flexShrink: 0 }}>
+      <img src="/promo/spring-sale.jpg" alt="Spring sale" style={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }} />
+    </div>
+    <Stack gap="2" style={{ flex: 1 }}>
+      <Row gap="2" align="center">
+        <Text size="md" weight="semibold">Spring Sale</Text>
+        <Chip variant="success" size="sm">-30%</Chip>
+      </Row>
+      <Text size="sm" color="secondary">All Pro plans are 30% off through April. Upgrade now and lock in the price for a year.</Text>
+      <Button variant="primary" size="sm" style={{ alignSelf: 'flex-start' }}>Claim offer</Button>
+    </Stack>
+  </Row>
+</Card>`,
+    },
+    {
+      title: 'Success confirmation',
+      code: `<Card variant="outline" padding="md" style={{ width: 400, borderColor: 'var(--lucent-success-default)' }}>
+  <Row gap="3" align="start">
+    <Icon size="lg" color="var(--lucent-success-text)">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round">
+        <path d="M22 11.08V12a10 10 0 11-5.93-9.14" />
+        <polyline points="22 4 12 14.01 9 11.01" />
+      </svg>
+    </Icon>
+    <Stack gap="1" style={{ flex: 1 }}>
+      <Text size="sm" weight="semibold">Payment received</Text>
+      <Text size="sm" color="secondary">Your invoice #1042 for $2,400.00 has been paid successfully.</Text>
+    </Stack>
+    <Button variant="ghost" size="sm">Dismiss</Button>
+  </Row>
+</Card>`,
+    },
+  ],
+
+  designNotes:
+    'The default announcement card uses the Card media slot for a full-bleed hero ' +
+    'image that grabs attention, followed by an optional Chip badge for categorization, ' +
+    'then title + description + action buttons. This distinguishes it from the Alert ' +
+    'molecule which is a lightweight status banner — the Announcement Card is richer, ' +
+    'supports media, and drives the user toward an action. The system notice variant ' +
+    'drops the media for a compact icon-led layout similar to Alert but with action ' +
+    'buttons. The promotional variant uses an inline thumbnail (Row with rounded image) ' +
+    'for a side-by-side layout that works well for offers and upsells. The success ' +
+    'variant uses a tinted border to reinforce status at a glance.',
+};


### PR DESCRIPTION
## Summary
- Adds `announcement-card` pattern in `src/manifest/patterns/notification-card.pattern.ts`
- Renamed from "Notification Card" to "Announcement Card" to distinguish from the Alert molecule — richer layout with media support and action buttons
- **Default**: elevated card with full-bleed media, badge chip, title/message, action + dismiss buttons
- **System notice**: compact icon-led layout with warning border and action buttons
- **Promotional banner**: inline thumbnail with side-by-side text and CTA
- **Success confirmation**: dismissible with tinted success border
- Registered in `server/pattern-registry.ts` — available via `get_composition_pattern` and `search_components`
- Added to dev ComponentPreview under Patterns > Cards

Closes #111

## Test plan
- [ ] `pnpm build:server` compiles cleanly
- [ ] `pnpm dev` — AnnouncementCard section renders all 4 variants without errors
- [ ] MCP: `get_composition_pattern` with `name: "announcement-card"` returns pattern with 3 variants
- [ ] MCP: `search_components` with `query: "announcement"` includes the pattern in results

🤖 Generated with [Claude Code](https://claude.com/claude-code)