### PR TITLE
feat: add Confirmation Dialog pattern

### DIFF
--- a/dev/ComponentPreview.tsx
+++ b/dev/ComponentPreview.tsx
@@ -218,7 +218,7 @@ function Inner({
     data:        { label: 'Data & Tables',      tier: 'molecule', items: ['DataTable', 'Timeline'] },
     overlays:    { label: 'Overlays & Menus',   tier: 'molecule', items: ['Menu', 'CommandPalette', 'Toast'] },
     'r-cards':   { label: 'Cards',              tier: 'pattern', items: ['ProfileCard', 'ProductItemCard', 'AnnouncementCard', 'CollapsibleCard', 'EmptyStateCard'] },
-    'r-layouts': { label: 'Layouts',            tier: 'pattern', items: ['SettingsPanel', 'FormLayout', 'StatsRow', 'ActionBar'] },
+    'r-layouts': { label: 'Layouts',            tier: 'pattern', items: ['SettingsPanel', 'FormLayout', 'StatsRow', 'ActionBar', 'ConfirmationDialog'] },
     'r-filters': { label: 'Filters',           tier: 'pattern', items: ['SearchFilterBar'] },
     'c-all':     { label: 'All Compositions',   tier: 'composition', items: ['GoldenProfileCard', 'GoldenPreferencesCard', 'GoldenPricingTable', 'GoldenNotificationFeed', 'GoldenOnboardingFlow', 'GoldenDashboardHeader'] },
   };
@@ -2877,6 +2877,73 @@ function Inner({
               <StackAtom gap="2">
                 <Text size="xs" color="secondary">No activity to show yet.</Text>
               </StackAtom>
+            </StackAtom>
+          </Card>
+        </Row>
+      </Section>
+
+      <Section title="ConfirmationDialog" tokens={tokens} hidden={!showSection('ConfirmationDialog')}>
+        <Row label="Destructive confirmation" tokens={tokens}>
+          <Card variant="elevated" padding="lg" style={{ maxWidth: 400 }}>
+            <StackAtom gap="8" align="center">
+              <Icon size="xl" color="var(--lucent-danger-text)">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" />
+                  <line x1={12} y1={9} x2={12} y2={13} />
+                  <line x1={12} y1={17} x2={12.01} y2={17} />
+                </svg>
+              </Icon>
+              <StackAtom gap="1" align="center">
+                <Text size="lg" weight="semibold">Delete project?</Text>
+                <Text size="sm" color="secondary" align="center">This will permanently delete &quot;Acme Corp&quot; and all of its data. This action cannot be undone.</Text>
+              </StackAtom>
+              <RowAtom gap="3" style={{ width: '100%' }}>
+                <Button variant="outline" style={{ flex: 1 }}>Cancel</Button>
+                <Button variant="danger" style={{ flex: 1 }}>Delete</Button>
+              </RowAtom>
+            </StackAtom>
+          </Card>
+        </Row>
+        <Row label="With typed confirmation" tokens={tokens}>
+          <Card variant="elevated" padding="lg" style={{ maxWidth: 400 }}>
+            <StackAtom gap="8" align="center">
+              <Icon size="xl" color="var(--lucent-danger-text)">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" />
+                  <line x1={12} y1={9} x2={12} y2={13} />
+                  <line x1={12} y1={17} x2={12.01} y2={17} />
+                </svg>
+              </Icon>
+              <StackAtom gap="1" align="center">
+                <Text size="lg" weight="semibold">Delete your account?</Text>
+                <Text size="sm" color="secondary" align="center">All projects, data, and billing history will be permanently removed. Type DELETE to confirm.</Text>
+              </StackAtom>
+              <Input placeholder="Type DELETE to confirm" size="md" style={{ width: '100%' }} />
+              <RowAtom gap="3" style={{ width: '100%' }}>
+                <Button variant="outline" style={{ flex: 1 }}>Cancel</Button>
+                <Button variant="danger" style={{ flex: 1 }} disabled>Delete account</Button>
+              </RowAtom>
+            </StackAtom>
+          </Card>
+        </Row>
+        <Row label="Non-destructive confirmation" tokens={tokens}>
+          <Card variant="elevated" padding="lg" style={{ maxWidth: 400 }}>
+            <StackAtom gap="8" align="center">
+              <Icon size="xl" color="var(--lucent-info-text)">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round">
+                  <circle cx={12} cy={12} r={10} />
+                  <line x1={12} y1={16} x2={12} y2={12} />
+                  <line x1={12} y1={8} x2={12.01} y2={8} />
+                </svg>
+              </Icon>
+              <StackAtom gap="1" align="center">
+                <Text size="lg" weight="semibold">Publish changes?</Text>
+                <Text size="sm" color="secondary" align="center">This will make your draft visible to all team members. You can unpublish later from settings.</Text>
+              </StackAtom>
+              <RowAtom gap="3" style={{ width: '100%' }}>
+                <Button variant="outline" style={{ flex: 1 }}>Keep as draft</Button>
+                <Button variant="primary" style={{ flex: 1 }}>Publish</Button>
+              </RowAtom>
             </StackAtom>
           </Card>
         </Row>

--- a/server/pattern-registry.ts
+++ b/server/pattern-registry.ts
@@ -10,6 +10,7 @@ import { PATTERN as CollapsibleCard } from '../src/manifest/patterns/collapsible
 import { PATTERN as SearchFilterBar } from '../src/manifest/patterns/search-filter-bar.pattern.js';
 import { PATTERN as ProductItemCard } from '../src/manifest/patterns/product-item-card.pattern.js';
 import { PATTERN as NotificationCard } from '../src/manifest/patterns/notification-card.pattern.js';
+import { PATTERN as ConfirmationDialog } from '../src/manifest/patterns/confirmation-dialog.pattern.js';
 
 export const ALL_PATTERNS: CompositionPattern[] = [
   ProfileCard,
@@ -22,4 +23,5 @@ export const ALL_PATTERNS: CompositionPattern[] = [
   SearchFilterBar,
   ProductItemCard,
   NotificationCard,
+  ConfirmationDialog,
 ];

--- a/src/manifest/patterns/confirmation-dialog.pattern.ts
+++ b/src/manifest/patterns/confirmation-dialog.pattern.ts
@@ -1,0 +1,102 @@
+import type { CompositionPattern } from '../types.js';
+
+export const PATTERN: CompositionPattern = {
+  id: 'confirmation-dialog',
+  name: 'Confirmation Dialog',
+  description: 'Centered modal-style card for destructive action confirmations with danger button pairing. For delete/remove/reset flows.',
+  category: 'action',
+  components: ['card', 'icon', 'text', 'button', 'input', 'stack', 'row'],
+
+  structure: `
+Card (elevated, padding="lg", maxWidth=400)
+└── Stack gap="8" align="center"
+    ├── Icon (lg, danger color)               ← warning icon
+    ├── Stack gap="1" align="center"
+    │   ├── Text (lg, semibold, center)       ← "Delete project?"
+    │   └── Text (sm, secondary, center)      ← consequence description
+    └── Row gap="3"
+        ├── Button (outline, full width)      ← "Cancel"
+        └── Button (danger, full width)       ← "Delete"
+  `.trim(),
+
+  code: `<Card variant="elevated" padding="lg" style={{ maxWidth: 400 }}>
+  <Stack gap="8" align="center">
+    <Icon size="xl" color="var(--lucent-danger-text)">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round">
+        <path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" />
+        <line x1={12} y1={9} x2={12} y2={13} />
+        <line x1={12} y1={17} x2={12.01} y2={17} />
+      </svg>
+    </Icon>
+    <Stack gap="1" align="center">
+      <Text size="lg" weight="semibold">Delete project?</Text>
+      <Text size="sm" color="secondary" align="center">This will permanently delete "Acme Corp" and all of its data. This action cannot be undone.</Text>
+    </Stack>
+    <Row gap="3" style={{ width: '100%' }}>
+      <Button variant="outline" style={{ flex: 1 }}>Cancel</Button>
+      <Button variant="danger" style={{ flex: 1 }}>Delete</Button>
+    </Row>
+  </Stack>
+</Card>`,
+
+  variants: [
+    {
+      title: 'With typed confirmation',
+      code: `<Card variant="elevated" padding="lg" style={{ maxWidth: 400 }}>
+  <Stack gap="8" align="center">
+    <Icon size="xl" color="var(--lucent-danger-text)">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round">
+        <path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" />
+        <line x1={12} y1={9} x2={12} y2={13} />
+        <line x1={12} y1={17} x2={12.01} y2={17} />
+      </svg>
+    </Icon>
+    <Stack gap="1" align="center">
+      <Text size="lg" weight="semibold">Delete your account?</Text>
+      <Text size="sm" color="secondary" align="center">All projects, data, and billing history will be permanently removed. Type DELETE to confirm.</Text>
+    </Stack>
+    <Input placeholder="Type DELETE to confirm" size="md" style={{ width: '100%' }} />
+    <Row gap="3" style={{ width: '100%' }}>
+      <Button variant="outline" style={{ flex: 1 }}>Cancel</Button>
+      <Button variant="danger" style={{ flex: 1 }} disabled>Delete account</Button>
+    </Row>
+  </Stack>
+</Card>`,
+    },
+    {
+      title: 'Non-destructive confirmation',
+      code: `<Card variant="elevated" padding="lg" style={{ maxWidth: 400 }}>
+  <Stack gap="8" align="center">
+    <Icon size="xl" color="var(--lucent-info-text)">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round">
+        <circle cx={12} cy={12} r={10} />
+        <line x1={12} y1={16} x2={12} y2={12} />
+        <line x1={12} y1={8} x2={12.01} y2={8} />
+      </svg>
+    </Icon>
+    <Stack gap="1" align="center">
+      <Text size="lg" weight="semibold">Publish changes?</Text>
+      <Text size="sm" color="secondary" align="center">This will make your draft visible to all team members. You can unpublish later from settings.</Text>
+    </Stack>
+    <Row gap="3" style={{ width: '100%' }}>
+      <Button variant="outline" style={{ flex: 1 }}>Keep as draft</Button>
+      <Button variant="primary" style={{ flex: 1 }}>Publish</Button>
+    </Row>
+  </Stack>
+</Card>`,
+    },
+  ],
+
+  designNotes:
+    'The centered layout with align="center" creates a focused, modal-like feel ' +
+    'even though this is a Card, not a true modal. The warning Icon at the top ' +
+    'provides an immediate visual signal of severity. The text stack uses gap="1" ' +
+    'to tightly couple the title and consequence description. Buttons use flex: 1 ' +
+    'inside a full-width Row so they split evenly — Cancel (outline) on the left, ' +
+    'destructive action (danger) on the right, following the convention of placing ' +
+    'the primary action on the right. The typed confirmation variant adds an Input ' +
+    'between the text and buttons with the danger Button disabled until the user ' +
+    'types the confirmation text. The non-destructive variant swaps the danger ' +
+    'Button for primary and the warning Icon for info, reusing the same centered ' +
+    'layout for any "are you sure?" flow.',
+};


### PR DESCRIPTION
## Summary
- Adds `confirmation-dialog` pattern in `src/manifest/patterns/confirmation-dialog.pattern.ts`
- **Default**: centered elevated card with danger warning icon, title, consequence text, Cancel + Delete buttons
- **Typed confirmation**: adds an Input field (size matched to buttons) — danger button disabled until user types DELETE
- **Non-destructive**: swaps danger for primary, warning for info icon — reusable for any "are you sure?" flow
- Registered in `server/pattern-registry.ts` — available via `get_composition_pattern` and `search_components`
- Added to dev ComponentPreview under Patterns > Layouts

Closes #114

## Test plan
- [ ] `pnpm build:server` compiles cleanly
- [ ] `pnpm dev` — ConfirmationDialog section renders all 3 variants without errors
- [ ] MCP: `get_composition_pattern` with `name: "confirmation-dialog"` returns pattern with 2 variants
- [ ] MCP: `search_components` with `query: "confirmation"` includes the pattern in results

🤖 Generated with [Claude Code](https://claude.com/claude-code)