### PR TITLE
fix: lighten disabled text color

### DIFF
--- a/src/tokens/derive.ts
+++ b/src/tokens/derive.ts
@@ -117,7 +117,7 @@ export function deriveTokens(
     if (!('textSecondary' in overrides))
       derived.textSecondary = adjustLightness(merged.textPrimary, isLight ? +0.20 : -0.15);
     if (!('textDisabled' in overrides))
-      derived.textDisabled = adjustLightness(merged.textPrimary, isLight ? +0.35 : -0.40);
+      derived.textDisabled = adjustLightness(merged.textPrimary, isLight ? +0.58 : -0.62);
   }
 
   // --- Accent variants ---

--- a/src/tokens/light.ts
+++ b/src/tokens/light.ts
@@ -35,7 +35,7 @@ export const lightTokens: LucentTokens = {
   // Text
   textPrimary: '#111827',
   textSecondary: '#6b7280',
-  textDisabled: '#9ca3af',
+  textDisabled: '#d1d5db',
   textInverse: '#ffffff',
   // Accent (monochrome default — near-black for universal, high-contrast out of the box)
   // Use `brandTokens` to opt in to the gold palette.


### PR DESCRIPTION
## Summary
- Disabled text was too close to secondary text, making disabled states hard to distinguish
- Bumped derived lightness offset: light mode `+0.35 → +0.58`, dark mode `−0.40 → −0.62`
- Updated hardcoded light default: `#9ca3af → #d1d5db`

## Test plan
- [ ] `pnpm dev` — toggle disabled state on inputs/buttons, verify text is clearly greyed out
- [ ] Check both light and dark mode
- [ ] Verify derived palettes (custom accent colors) also produce visibly lighter disabled text

🤖 Generated with [Claude Code](https://claude.com/claude-code)