### PR TITLE
feat: add Bulk Action Bar pattern

### DIFF
--- a/dev/ComponentPreview.tsx
+++ b/dev/ComponentPreview.tsx
@@ -218,7 +218,7 @@ function Inner({
     data:        { label: 'Data & Tables',      tier: 'molecule', items: ['DataTable', 'Timeline'] },
     overlays:    { label: 'Overlays & Menus',   tier: 'molecule', items: ['Menu', 'CommandPalette', 'Toast'] },
     'r-cards':   { label: 'Cards',              tier: 'pattern', items: ['ProfileCard', 'ProductItemCard', 'AnnouncementCard', 'CollapsibleCard', 'EmptyStateCard'] },
-    'r-layouts': { label: 'Layouts',            tier: 'pattern', items: ['SettingsPanel', 'FormLayout', 'StatsRow', 'ActionBar', 'ConfirmationDialog'] },
+    'r-layouts': { label: 'Layouts',            tier: 'pattern', items: ['SettingsPanel', 'FormLayout', 'StatsRow', 'ActionBar', 'ConfirmationDialog', 'BulkActionBar'] },
     'r-filters': { label: 'Filters',           tier: 'pattern', items: ['SearchFilterBar'] },
     'c-all':     { label: 'All Compositions',   tier: 'composition', items: ['GoldenProfileCard', 'GoldenPreferencesCard', 'GoldenPricingTable', 'GoldenNotificationFeed', 'GoldenOnboardingFlow', 'GoldenDashboardHeader'] },
   };
@@ -2946,6 +2946,49 @@ function Inner({
               </RowAtom>
             </StackAtom>
           </Card>
+        </Row>
+      </Section>
+
+      <Section title="BulkActionBar" tokens={tokens} hidden={!showSection('BulkActionBar')}>
+        <Row label="Default (ButtonGroup actions)" tokens={tokens}>
+          <RowAtom gap="3" align="center" style={{ width: '100%', maxWidth: 600, padding: 'var(--lucent-space-3) var(--lucent-space-4)', background: tokens.surface, borderRadius: 'var(--lucent-radius-lg)', border: `1px solid ${tokens.borderDefault}` }}>
+            <Checkbox indeterminate checked onChange={() => {}} />
+            <Text size="sm" weight="semibold">3 selected</Text>
+            <Divider orientation="vertical" />
+            <ButtonGroup>
+              <Button variant="outline" size="sm">Export</Button>
+              <Button variant="outline" size="sm">Archive</Button>
+              <Button variant="danger-outline" size="sm">Delete</Button>
+            </ButtonGroup>
+            <RowAtom style={{ flex: 1, justifyContent: 'flex-end' }}>
+              <Button variant="ghost" size="sm">Clear selection</Button>
+            </RowAtom>
+          </RowAtom>
+        </Row>
+        <Row label="Minimal (single action)" tokens={tokens}>
+          <RowAtom gap="3" align="center" style={{ width: '100%', maxWidth: 600, padding: 'var(--lucent-space-3) var(--lucent-space-4)', background: tokens.surface, borderRadius: 'var(--lucent-radius-lg)', border: `1px solid ${tokens.borderDefault}` }}>
+            <Checkbox checked onChange={() => {}} />
+            <Text size="sm" weight="semibold">12 selected</Text>
+            <RowAtom style={{ flex: 1, justifyContent: 'flex-end' }}>
+              <Button variant="danger" size="sm">Delete selected</Button>
+            </RowAtom>
+          </RowAtom>
+        </Row>
+        <Row label="With count and secondary actions" tokens={tokens}>
+          <RowAtom gap="3" align="center" style={{ width: '100%', maxWidth: 600, padding: 'var(--lucent-space-3) var(--lucent-space-4)', background: tokens.surface, borderRadius: 'var(--lucent-radius-lg)', border: `1px solid ${tokens.borderDefault}` }}>
+            <Checkbox indeterminate checked onChange={() => {}} />
+            <RowAtom gap="2" align="center">
+              <Text size="sm" weight="semibold">5 of 24 selected</Text>
+              <Button variant="ghost" size="xs">Select all</Button>
+            </RowAtom>
+            <Divider orientation="vertical" />
+            <Button variant="outline" size="sm">Assign label</Button>
+            <Button variant="outline" size="sm">Move to</Button>
+            <Button variant="danger-outline" size="sm">Delete</Button>
+            <RowAtom style={{ flex: 1, justifyContent: 'flex-end' }}>
+              <Button variant="ghost" size="sm">Clear</Button>
+            </RowAtom>
+          </RowAtom>
         </Row>
       </Section>
 

--- a/server/pattern-registry.ts
+++ b/server/pattern-registry.ts
@@ -11,6 +11,7 @@ import { PATTERN as SearchFilterBar } from '../src/manifest/patterns/search-filt
 import { PATTERN as ProductItemCard } from '../src/manifest/patterns/product-item-card.pattern.js';
 import { PATTERN as NotificationCard } from '../src/manifest/patterns/notification-card.pattern.js';
 import { PATTERN as ConfirmationDialog } from '../src/manifest/patterns/confirmation-dialog.pattern.js';
+import { PATTERN as BulkActionBar } from '../src/manifest/patterns/bulk-action-bar.pattern.js';
 
 export const ALL_PATTERNS: CompositionPattern[] = [
   ProfileCard,
@@ -24,4 +25,5 @@ export const ALL_PATTERNS: CompositionPattern[] = [
   ProductItemCard,
   NotificationCard,
   ConfirmationDialog,
+  BulkActionBar,
 ];

--- a/src/manifest/patterns/bulk-action-bar.pattern.ts
+++ b/src/manifest/patterns/bulk-action-bar.pattern.ts
@@ -1,0 +1,78 @@
+import type { CompositionPattern } from '../types.js';
+
+export const PATTERN: CompositionPattern = {
+  id: 'bulk-action-bar',
+  name: 'Bulk Action Bar',
+  description: 'Sticky bar that appears when table rows are selected. Shows selection count, bulk action buttons, and a clear selection control.',
+  category: 'action',
+  components: ['checkbox', 'text', 'button', 'button-group', 'divider', 'row'],
+
+  structure: `
+Row gap="3" align="center" (surface background, padding=md)
+├── Checkbox (indeterminate when partial)
+├── Text (sm, semibold)              ← "3 selected"
+├── Divider (vertical)
+├── ButtonGroup
+│   ├── Button (outline, sm)         ← "Export"
+│   ├── Button (outline, sm)         ← "Archive"
+│   └── Button (danger-outline, sm)  ← "Delete"
+└── Row flex=1 justify="end"
+    └── Button (ghost, sm)           ← "Clear selection"
+  `.trim(),
+
+  code: `<Row gap="3" align="center" style={{ padding: 'var(--lucent-space-3) var(--lucent-space-4)', background: 'var(--lucent-surface)', borderRadius: 'var(--lucent-radius-lg)', border: '1px solid var(--lucent-border-default)' }}>
+  <Checkbox indeterminate checked onChange={() => {}} />
+  <Text size="sm" weight="semibold">3 selected</Text>
+  <Divider orientation="vertical" />
+  <ButtonGroup>
+    <Button variant="outline" size="sm">Export</Button>
+    <Button variant="outline" size="sm">Archive</Button>
+    <Button variant="danger-outline" size="sm">Delete</Button>
+  </ButtonGroup>
+  <Row style={{ flex: 1, justifyContent: 'flex-end' }}>
+    <Button variant="ghost" size="sm">Clear selection</Button>
+  </Row>
+</Row>`,
+
+  variants: [
+    {
+      title: 'Minimal (single action)',
+      code: `<Row gap="3" align="center" style={{ padding: 'var(--lucent-space-3) var(--lucent-space-4)', background: 'var(--lucent-surface)', borderRadius: 'var(--lucent-radius-lg)', border: '1px solid var(--lucent-border-default)' }}>
+  <Checkbox checked onChange={() => {}} />
+  <Text size="sm" weight="semibold">12 selected</Text>
+  <Row style={{ flex: 1, justifyContent: 'flex-end' }}>
+    <Button variant="danger" size="sm">Delete selected</Button>
+  </Row>
+</Row>`,
+    },
+    {
+      title: 'With count badge and secondary actions',
+      code: `<Row gap="3" align="center" style={{ padding: 'var(--lucent-space-3) var(--lucent-space-4)', background: 'var(--lucent-surface)', borderRadius: 'var(--lucent-radius-lg)', border: '1px solid var(--lucent-border-default)' }}>
+  <Checkbox indeterminate checked onChange={() => {}} />
+  <Row gap="2" align="center">
+    <Text size="sm" weight="semibold">5 of 24 selected</Text>
+    <Button variant="ghost" size="xs">Select all</Button>
+  </Row>
+  <Divider orientation="vertical" />
+  <Button variant="outline" size="sm">Assign label</Button>
+  <Button variant="outline" size="sm">Move to</Button>
+  <Button variant="danger-outline" size="sm">Delete</Button>
+  <Row style={{ flex: 1, justifyContent: 'flex-end' }}>
+    <Button variant="ghost" size="sm">Clear</Button>
+  </Row>
+</Row>`,
+    },
+  ],
+
+  designNotes:
+    'The bar uses a Row with center alignment so all elements sit on the same ' +
+    'horizontal baseline. The Checkbox reflects selection state — indeterminate ' +
+    'when some rows are selected, checked when all are. A vertical Divider ' +
+    'visually separates the selection count from the action buttons. ButtonGroup ' +
+    'clusters related actions with shared border radius. The danger-outline ' +
+    'variant on the Delete button signals destructive intent without the visual ' +
+    'weight of a filled danger button. The clear selection Button is pushed to ' +
+    'the far right via flex: 1 on its wrapper Row, keeping it accessible but ' +
+    'visually subordinate. The minimal variant drops the ButtonGroup and Divider ' +
+    'for a simpler single-action layout.',
+};


### PR DESCRIPTION
## Summary
- Adds `bulk-action-bar` pattern in `src/manifest/patterns/bulk-action-bar.pattern.ts`
- **Default**: indeterminate checkbox, "3 selected" count, vertical divider, ButtonGroup with Export/Archive/Delete, right-aligned clear selection
- **Minimal**: single danger button with checkbox and count — for simple bulk delete flows
- **Extended**: partial count ("5 of 24 selected") with "Select all" ghost button, individual action buttons
- Registered in `server/pattern-registry.ts` — available via `get_composition_pattern` and `search_components`
- Added to dev ComponentPreview under Patterns > Layouts

Closes #115

## Test plan
- [ ] `pnpm build:server` compiles cleanly
- [ ] `pnpm dev` — BulkActionBar section renders all 3 variants without errors
- [ ] MCP: `get_composition_pattern` with `name: "bulk-action-bar"` returns pattern with 2 variants
- [ ] MCP: `search_components` with `query: "bulk action"` includes the pattern in results

🤖 Generated with [Claude Code](https://claude.com/claude-code)