### PR TITLE
chore(website): update content for patterns and design rules

### DIFF
--- a/website/src/components/ComponentGrid.astro
+++ b/website/src/components/ComponentGrid.astro
@@ -10,13 +10,14 @@ const molecules = [
   'FormField', 'SearchInput', 'Card', 'Alert', 'EmptyState', 'Skeleton',
   'Breadcrumb', 'Tabs', 'Collapsible', 'PageLayout', 'DataTable', 'Menu',
   'NavMenu', 'CommandPalette', 'MultiSelect', 'DatePicker', 'DateRangePicker',
-  'FileUpload', 'Timeline', 'Toast', 'FilterSearch', 'FilterSelect',
+  'FileUpload', 'Timeline', 'Toast', 'Stepper', 'FilterSearch', 'FilterSelect',
   'FilterMultiSelect', 'FilterDateRange',
 ];
 
-const recipes = [
+const patterns = [
   'Profile Card', 'Settings Panel', 'Stats Row', 'Action Bar',
   'Form Layout', 'Empty State Card', 'Collapsible Card', 'Search / Filter Bar',
+  'Product / Item Card', 'Announcement Card', 'Confirmation Dialog', 'Bulk Action Bar',
 ];
 ---
 
@@ -30,8 +31,8 @@ const recipes = [
           Everything you need.<br>Nothing you <em>don't.</em>
         </h2>
         <p class="section-body">
-          {atoms.length + molecules.length} components across two tiers, plus {recipes.length} composition
-          recipes for real-world UI patterns. Every single one ships with a
+          {atoms.length + molecules.length} components across two tiers, plus {patterns.length} composition
+          patterns for real-world UI layouts. Every component ships with a
           <code class="inline-code">COMPONENT_MANIFEST</code>.
         </p>
       </div>
@@ -45,8 +46,8 @@ const recipes = [
           <span class="count-label">Molecules</span>
         </div>
         <div class="count-pill">
-          <span class="count-num">{recipes.length}</span>
-          <span class="count-label">Recipes</span>
+          <span class="count-num">{patterns.length}</span>
+          <span class="count-label">Patterns</span>
         </div>
       </div>
     </div>
@@ -83,14 +84,14 @@ const recipes = [
 
     <div class="tier-block">
       <div class="tier-label">
-        <span class="tier-tag">Recipes</span>
-        <span class="tier-desc">Real-world compositions with working code and variants</span>
+        <span class="tier-tag">Patterns</span>
+        <span class="tier-desc">Real-world composition templates with working code, variants, and design notes</span>
       </div>
       <div class="component-grid">
-        {recipes.map(name => (
+        {patterns.map(name => (
           <div class="component-card">
             <span class="component-name">{name}</span>
-            <span class="component-tag">recipe</span>
+            <span class="component-tag">pattern</span>
           </div>
         ))}
       </div>

--- a/website/src/components/Hero.astro
+++ b/website/src/components/Hero.astro
@@ -53,11 +53,13 @@ const version = pkg.version;
     <!-- Feature pills -->
     <div class="pills">
       <span class="pill pill-gold">COMPONENT_MANIFEST</span>
-      <span class="pill pill-gold">createTheme()</span>
       <span class="pill pill-gold">MCP Server</span>
+      <span class="pill pill-gold">Design Rules</span>
+      <span class="pill pill-gold">Composition Patterns</span>
+      <span class="pill pill-gold">createTheme()</span>
       <span class="pill pill-gold">DevTools</span>
-      <span class="pill pill-gold">Design Presets</span>
-      <span class="pill">52+ Components</span>
+      <span class="pill">53+ Components</span>
+      <span class="pill">12 Patterns</span>
       <span class="pill">React 18 / 19</span>
       <span class="pill">Claude · Cursor · Copilot</span>
       <span class="pill">Open Source</span>

--- a/website/src/components/McpSection.astro
+++ b/website/src/components/McpSection.astro
@@ -12,8 +12,8 @@
       </h2>
       <p class="section-body">
         Lucent UI ships an MCP (Model Context Protocol) server. Point your AI assistant
-        at it and it gains full access to every component manifest, theme anchors spec,
-        and usage examples — without touching your project source.
+        at it and it gains full access to every component manifest, design rules,
+        composition patterns, and theme spec — without touching your project source.
       </p>
 
       <div class="ai-tools">
@@ -83,15 +83,22 @@
         <div class="mcp-feature">
           <span class="mcp-feature-dot"></span>
           <div>
-            <div class="mcp-feature-title">Composition recipes</div>
-            <div class="mcp-feature-body">8 real-world UI patterns — profile cards, settings panels, filter bars — with working code and variants</div>
+            <div class="mcp-feature-title">Design rules</div>
+            <div class="mcp-feature-body">Spacing scale, typography hierarchy, button pairing, and layout patterns — injected into the AI's system prompt automatically</div>
+          </div>
+        </div>
+        <div class="mcp-feature">
+          <span class="mcp-feature-dot"></span>
+          <div>
+            <div class="mcp-feature-title">Composition patterns</div>
+            <div class="mcp-feature-body">12 real-world UI templates — product cards, confirmation dialogs, bulk action bars — with structure trees, working code, and variants</div>
           </div>
         </div>
         <div class="mcp-feature">
           <span class="mcp-feature-dot"></span>
           <div>
             <div class="mcp-feature-title">Zero hallucinations</div>
-            <div class="mcp-feature-body">The AI only uses prop names and values that actually exist in the library</div>
+            <div class="mcp-feature-body">The AI only uses prop names, variants, and layout patterns that actually exist in the library</div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- **Hero pills**: replaced "Design Presets" with "Design Rules" and "Composition Patterns" (gold), updated "52+" → "53+ Components", added "12 Patterns"
- **ComponentGrid**: renamed "recipes" → "patterns" throughout, added 4 new patterns (Product/Item Card, Announcement Card, Confirmation Dialog, Bulk Action Bar), added Stepper to molecules, updated copy
- **McpSection**: added "Design rules" feature bullet (spacing, typography, button pairing injected into system prompt), renamed "Composition recipes" → "Composition patterns", updated count from 8 → 12, updated "Zero hallucinations" copy

## Test plan
- [ ] `pnpm build` in website/ succeeds
- [ ] Hero pills show updated feature list with correct counts
- [ ] Component grid shows 28 atoms, 25 molecules, 12 patterns
- [ ] MCP section lists 5 features: manifests, theme spec, design rules, patterns, zero hallucinations

🤖 Generated with [Claude Code](https://claude.com/claude-code)