### PR TITLE
feat: per-user API keys for MCP HTTP server (#151)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules/
 dist/
 dist-server/
 dist-cli/
+data/
 .DS_Store
 *.local
 .env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,15 @@
 # syntax=docker/dockerfile:1.7
 
 # Build the MCP HTTP server (server/http.ts → dist-server/server/http.js).
+# better-sqlite3 is a native module; the build stage has the toolchain and
+# compiles it once, then the runtime stage copies the compiled node_modules
+# so the final image stays lean.
 FROM node:22-alpine AS builder
 
 WORKDIR /app
+
+# Build toolchain for node-gyp fallback when prebuilds are missing.
+RUN apk add --no-cache python3 make g++
 
 RUN corepack enable && corepack prepare pnpm@10.30.3 --activate
 
@@ -16,21 +22,23 @@ COPY src ./src
 
 RUN pnpm build:server
 
-# Runtime image — production deps + compiled server only.
+# Strip dev deps but keep compiled native modules (better-sqlite3).
+RUN pnpm prune --prod
+
 FROM node:22-alpine AS runtime
 
 WORKDIR /app
 
-RUN corepack enable && corepack prepare pnpm@10.30.3 --activate
-
-COPY package.json pnpm-lock.yaml ./
-RUN pnpm install --frozen-lockfile --prod
-
+# Copy the pre-compiled production node_modules from the builder so we don't
+# need python/make/g++ in the runtime image.
+COPY --from=builder /app/package.json ./package.json
+COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/dist-server ./dist-server
 
 ENV NODE_ENV=production \
     HOST=0.0.0.0 \
-    PORT=3000
+    PORT=3000 \
+    LUCENT_KEY_DB=/data/keys.db
 
 EXPOSE 3000
 

--- a/docs/MCP_HOSTING.md
+++ b/docs/MCP_HOSTING.md
@@ -6,9 +6,9 @@ This doc covers:
 
 1. Why Fly, and the shape of the deploy
 2. First-time deploy
-3. Setting and rotating `LUCENT_API_KEY`
-4. DNS cutover
-5. Local fallback via `cloudflared`
+3. Per-user API keys (mint, list, revoke, rotate)
+4. Custom domain setup
+5. Local development
 
 ## Why Fly
 
@@ -34,11 +34,12 @@ Railway, Vercel (via `@vercel/mcp-adapter`), and Cloudflare Workers were conside
 Prerequisites: [`flyctl`](https://fly.io/docs/hands-on/install-flyctl/) installed and logged in (`fly auth login`).
 
 ```bash
-# From the repo root. Creates the app on first run, deploys a new revision on later runs.
-fly deploy
+fly apps create lucent-mcp
+fly volumes create lucent_mcp_data --app lucent-mcp --region iad --size 1
+fly deploy --app lucent-mcp
 ```
 
-The app name (`lucent-mcp`) and region (`iad`) come from `fly.toml`. Change them there if you need a different region or want a throwaway staging app.
+The `lucent_mcp_data` volume holds the SQLite key database (`/data/keys.db` inside the container). A 1 GB volume is far more than needed — Fly's minimum — and survives deploys.
 
 Verify the deploy:
 
@@ -48,35 +49,63 @@ curl https://lucent-mcp.fly.dev/health
 
 # Should return 401 Unauthorized (no bearer token)
 curl -i https://lucent-mcp.fly.dev/mcp -X POST
-
-# Should return a JSON-RPC response listing tools
-curl -s https://lucent-mcp.fly.dev/mcp \
-  -X POST \
-  -H "Authorization: Bearer $LUCENT_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
 ```
 
-## Setting and rotating `LUCENT_API_KEY`
+To actually call `/mcp` you need a key — mint one via the admin CLI below.
 
-The server requires a bearer token for `/mcp`, `/usage`, and `/usage/stream`. `/health` is intentionally unauthenticated so Fly's health check can probe it.
+## Per-user API keys
 
-**Set the secret** (only needed once, or when rotating):
+Every `/mcp`, `/usage`, and `/usage/stream` request requires `Authorization: Bearer <key>`. Keys are stored as sha256 hashes in the SQLite DB on the Fly volume — plaintext is only shown once at mint time. (`/health` stays unauthenticated so Fly's probe works.)
+
+### Mint a key
+
+Keys are minted via `lucent-mcp-admin`, which is shipped in the container. Run it over `fly ssh console`:
 
 ```bash
-# Generate a strong random key and push it to Fly's secret store.
-# `fly secrets set` triggers a rolling restart, so the new key takes effect immediately.
-fly secrets set LUCENT_API_KEY="$(openssl rand -hex 32)"
+fly ssh console --app lucent-mcp
+# inside the container:
+node dist-server/server/admin.js mint alice@example.com
 ```
 
-**Rotate**:
+The output includes the plaintext key once — save it, it will not be shown again. Hand it to the user for their MCP client's `Authorization: Bearer …` header.
 
-1. Generate the new key: `NEW_KEY=$(openssl rand -hex 32)`
-2. Distribute to beta users through your usual channel *before* cutting over (they'll need to update their MCP client config).
-3. `fly secrets set LUCENT_API_KEY="$NEW_KEY"` — rolling restart happens automatically.
-4. Old key stops working as soon as the new machine comes up.
+### List keys
 
-Until issue #151 lands (per-user API keys), this is a single shared secret — rotation affects every beta user at once.
+```bash
+node dist-server/server/admin.js list
+```
+
+Shows label, masked hash, created/last-used timestamps, and revoked state for every key.
+
+### Revoke a key
+
+```bash
+node dist-server/server/admin.js revoke alice@example.com
+# or by hash prefix:
+node dist-server/server/admin.js revoke a1b2c3d4
+```
+
+Revocation is a soft delete (sets `revoked_at`) — the row stays for audit purposes, but the key stops authenticating immediately.
+
+### End-of-beta bulk revoke
+
+To kill every active key at once (e.g. when the beta ends):
+
+```bash
+fly ssh console --app lucent-mcp
+# inside the container:
+sqlite3 /data/keys.db "UPDATE keys SET revoked_at = datetime('now') WHERE revoked_at IS NULL"
+```
+
+### Legacy `LUCENT_API_KEY` (transition only)
+
+Before per-user keys landed, auth was a single shared `LUCENT_API_KEY` secret. The server still accepts that value if the secret is set, as a fallback during cutover. Once the first DB key is minted and confirmed working, remove the legacy secret:
+
+```bash
+fly secrets unset LUCENT_API_KEY --app lucent-mcp
+```
+
+After that, only DB keys authenticate.
 
 ## Custom domain
 
@@ -98,17 +127,20 @@ Production hostname is `mcp.lucentui.ai`, pointed at the Fly app via Cloudflare 
    curl https://mcp.lucentui.ai/health
    ```
 
-## Local fallback via `cloudflared`
+## Local development
 
-The managed Fly app is the source of truth, but you can still run `lucent-mcp-http` locally and expose it via Cloudflare Tunnel for quick iteration — useful when testing a change before pushing to Fly.
+The managed Fly app is the source of truth, but you can run `lucent-mcp-http` locally for quick iteration. The local server uses the same admin CLI against a local SQLite file.
 
 ```bash
-# In one shell, run the server locally.
 pnpm build:server
-LUCENT_API_KEY=dev-only HOST=127.0.0.1 PORT=3000 node dist-server/server/http.js
 
-# In another shell, expose it through the named tunnel.
-cloudflared tunnel run lucent-mcp
+# Mint a dev key (first run creates ./data/keys.db)
+node dist-server/server/admin.js mint dev
+
+# Start the server
+HOST=127.0.0.1 PORT=3000 node dist-server/server/http.js
 ```
 
-Point your MCP client at `http://127.0.0.1:3000/mcp` for pure-local dev, or at the named-tunnel hostname for remote clients. Do not use the production DNS (`mcp.lucentui.ai`) for local work — it lives with Fly now.
+Point your MCP client at `http://127.0.0.1:3000/mcp` with the minted key as the bearer token. Do not use the production DNS (`mcp.lucentui.ai`) for local work — it lives with Fly.
+
+To expose the local server to remote clients, pair it with a Cloudflare Tunnel (`cloudflared tunnel run …`). Not needed for most iteration.

--- a/fly.toml
+++ b/fly.toml
@@ -10,7 +10,13 @@ primary_region = "iad"
 [env]
   HOST = "0.0.0.0"
   PORT = "3000"
-  # LUCENT_API_KEY is set via `fly secrets set` — never commit it here.
+  LUCENT_KEY_DB = "/data/keys.db"
+  # LUCENT_API_KEY is still accepted as a legacy fallback during cutover;
+  # unset via `fly secrets unset LUCENT_API_KEY` once a DB key is minted.
+
+[[mounts]]
+  source = "lucent_mcp_data"
+  destination = "/data"
 
 [http_service]
   internal_port = 3000

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "lucent-ui": "./dist-cli/cli/entry.js",
     "lucent-mcp": "./dist-server/server/index.js",
     "lucent-mcp-http": "./dist-server/server/http.js",
+    "lucent-mcp-admin": "./dist-server/server/admin.js",
     "lucent-manifest": "./dist-cli/cli/index.js"
   },
   "sideEffects": false,
@@ -67,6 +68,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
+    "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^25.3.3",
     "@types/react": "^18.3.28",
     "@types/react-dom": "^18.3.7",
@@ -82,6 +84,10 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
+    "better-sqlite3": "^12.9.0",
     "zod": "^4.3.6"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": ["better-sqlite3", "esbuild"]
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.27.1
         version: 1.27.1(zod@4.3.6)
+      better-sqlite3:
+        specifier: ^12.9.0
+        version: 12.9.0
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -27,6 +30,9 @@ importers:
       '@testing-library/user-event':
         specifier: ^14.6.1
         version: 14.6.1(@testing-library/dom@10.4.1)
+      '@types/better-sqlite3':
+        specifier: ^7.6.13
+        version: 7.6.13
       '@types/node':
         specifier: ^25.3.3
         version: 25.3.3
@@ -919,6 +925,9 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/better-sqlite3@7.6.13':
+    resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -1108,6 +1117,9 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
   baseline-browser-mapping@2.10.0:
     resolution: {integrity: sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==}
     engines: {node: '>=6.0.0'}
@@ -1117,8 +1129,18 @@ packages:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
 
+  better-sqlite3@12.9.0:
+    resolution: {integrity: sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==}
+    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x}
+
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+
+  bl@4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
   body-parser@2.2.2:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
@@ -1139,6 +1161,9 @@ packages:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -1161,6 +1186,9 @@ packages:
 
   chardet@2.1.1:
     resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
+
+  chownr@1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
@@ -1235,6 +1263,14 @@ packages:
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
+  decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
+
+  deep-extend@0.6.0:
+    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
+    engines: {node: '>=4.0.0'}
+
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
@@ -1249,6 +1285,10 @@ packages:
 
   detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
+    engines: {node: '>=8'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
   diff@8.0.3:
@@ -1282,6 +1322,9 @@ packages:
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
   enquirer@2.4.1:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
@@ -1358,6 +1401,10 @@ packages:
     resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
     engines: {node: '>=18.0.0'}
 
+  expand-template@2.0.3:
+    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
+    engines: {node: '>=6'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -1403,6 +1450,9 @@ packages:
   fflate@0.8.2:
     resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
 
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
@@ -1436,6 +1486,9 @@ packages:
   fresh@2.0.0:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
+
+  fs-constants@1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
   fs-extra@11.3.4:
     resolution: {integrity: sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==}
@@ -1471,6 +1524,9 @@ packages:
 
   get-tsconfig@4.13.6:
     resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
+
+  github-from-package@0.0.0:
+    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -1530,6 +1586,9 @@ packages:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
 
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -1544,6 +1603,9 @@ packages:
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
   ip-address@10.0.1:
     resolution: {integrity: sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==}
@@ -1712,6 +1774,10 @@ packages:
     resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
     engines: {node: '>=18'}
 
+  mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
+
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
@@ -1723,6 +1789,12 @@ packages:
   minimatch@9.0.9:
     resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
   mlly@1.8.0:
     resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
@@ -1746,9 +1818,16 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  napi-build-utils@2.0.0:
+    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
+
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
+
+  node-abi@3.89.0:
+    resolution: {integrity: sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==}
+    engines: {node: '>=10'}
 
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
@@ -1871,6 +1950,12 @@ packages:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  prebuild-install@7.1.3:
+    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
+    engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
+    hasBin: true
+
   prettier@2.8.8:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
     engines: {node: '>=10.13.0'}
@@ -1883,6 +1968,9 @@ packages:
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
+
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -1906,6 +1994,10 @@ packages:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
 
+  rc@1.2.8:
+    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    hasBin: true
+
   react-dom@18.3.1:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
     peerDependencies:
@@ -1925,6 +2017,10 @@ packages:
   read-yaml-file@1.1.0:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
     engines: {node: '>=6'}
+
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
 
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
@@ -1961,6 +2057,9 @@ packages:
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
@@ -2023,6 +2122,12 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  simple-concat@1.0.1:
+    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+
+  simple-get@4.0.1:
+    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
+
   sirv@3.0.2:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
     engines: {node: '>=18'}
@@ -2059,6 +2164,9 @@ packages:
     resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
     engines: {node: '>=0.6.19'}
 
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
@@ -2070,6 +2178,10 @@ packages:
   strip-indent@3.0.0:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
     engines: {node: '>=8'}
+
+  strip-json-comments@2.0.1:
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
+    engines: {node: '>=0.10.0'}
 
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
@@ -2085,6 +2197,13 @@ packages:
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
+  tar-fs@2.1.4:
+    resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
+
+  tar-stream@2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
+    engines: {node: '>=6'}
 
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
@@ -2140,6 +2259,9 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
+  tunnel-agent@0.6.0:
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
+
   type-is@2.0.1:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
@@ -2187,6 +2309,9 @@ packages:
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
@@ -3116,6 +3241,10 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
+  '@types/better-sqlite3@7.6.13':
+    dependencies:
+      '@types/node': 25.3.3
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -3324,15 +3453,32 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
+  base64-js@1.5.1: {}
+
   baseline-browser-mapping@2.10.0: {}
 
   better-path-resolve@1.0.0:
     dependencies:
       is-windows: 1.0.2
 
+  better-sqlite3@12.9.0:
+    dependencies:
+      bindings: 1.5.0
+      prebuild-install: 7.1.3
+
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
+
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
+
+  bl@4.1.0:
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
 
   body-parser@2.2.2:
     dependencies:
@@ -3368,6 +3514,11 @@ snapshots:
       node-releases: 2.0.36
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
 
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
   bytes@3.1.2: {}
 
   call-bind-apply-helpers@1.0.2:
@@ -3385,6 +3536,8 @@ snapshots:
   chai@6.2.2: {}
 
   chardet@2.1.1: {}
+
+  chownr@1.1.4: {}
 
   combined-stream@1.0.8:
     dependencies:
@@ -3443,6 +3596,12 @@ snapshots:
 
   decimal.js@10.6.0: {}
 
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+
+  deep-extend@0.6.0: {}
+
   delayed-stream@1.0.0: {}
 
   depd@2.0.0: {}
@@ -3450,6 +3609,8 @@ snapshots:
   dequal@2.0.3: {}
 
   detect-indent@6.1.0: {}
+
+  detect-libc@2.1.2: {}
 
   diff@8.0.3: {}
 
@@ -3474,6 +3635,10 @@ snapshots:
   electron-to-chromium@1.5.307: {}
 
   encodeurl@2.0.0: {}
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
 
   enquirer@2.4.1:
     dependencies:
@@ -3581,6 +3746,8 @@ snapshots:
     dependencies:
       eventsource-parser: 3.0.6
 
+  expand-template@2.0.3: {}
+
   expect-type@1.3.0: {}
 
   express-rate-limit@8.2.1(express@5.2.1):
@@ -3647,6 +3814,8 @@ snapshots:
 
   fflate@0.8.2: {}
 
+  file-uri-to-path@1.0.0: {}
+
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
@@ -3687,6 +3856,8 @@ snapshots:
   forwarded@0.2.0: {}
 
   fresh@2.0.0: {}
+
+  fs-constants@1.0.0: {}
 
   fs-extra@11.3.4:
     dependencies:
@@ -3734,6 +3905,8 @@ snapshots:
   get-tsconfig@4.13.6:
     dependencies:
       resolve-pkg-maps: 1.0.0
+
+  github-from-package@0.0.0: {}
 
   glob-parent@5.1.2:
     dependencies:
@@ -3792,6 +3965,8 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  ieee754@1.2.1: {}
+
   ignore@5.3.2: {}
 
   import-lazy@4.0.0: {}
@@ -3799,6 +3974,8 @@ snapshots:
   indent-string@4.0.0: {}
 
   inherits@2.0.4: {}
+
+  ini@1.3.8: {}
 
   ip-address@10.0.1: {}
 
@@ -3950,6 +4127,8 @@ snapshots:
     dependencies:
       mime-db: 1.54.0
 
+  mimic-response@3.1.0: {}
+
   min-indent@1.0.1: {}
 
   minimatch@10.2.1:
@@ -3959,6 +4138,10 @@ snapshots:
   minimatch@9.0.9:
     dependencies:
       brace-expansion: 2.0.2
+
+  minimist@1.2.8: {}
+
+  mkdirp-classic@0.5.3: {}
 
   mlly@1.8.0:
     dependencies:
@@ -3977,7 +4160,13 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  napi-build-utils@2.0.0: {}
+
   negotiator@1.0.0: {}
+
+  node-abi@3.89.0:
+    dependencies:
+      semver: 7.5.4
 
   node-domexception@1.0.0: {}
 
@@ -4071,6 +4260,21 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  prebuild-install@7.1.3:
+    dependencies:
+      detect-libc: 2.1.2
+      expand-template: 2.0.3
+      github-from-package: 0.0.0
+      minimist: 1.2.8
+      mkdirp-classic: 0.5.3
+      napi-build-utils: 2.0.0
+      node-abi: 3.89.0
+      pump: 3.0.4
+      rc: 1.2.8
+      simple-get: 4.0.1
+      tar-fs: 2.1.4
+      tunnel-agent: 0.6.0
+
   prettier@2.8.8: {}
 
   pretty-format@27.5.1:
@@ -4083,6 +4287,11 @@ snapshots:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
+
+  pump@3.0.4:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
 
   punycode@2.3.1: {}
 
@@ -4102,6 +4311,13 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       unpipe: 1.0.0
+
+  rc@1.2.8:
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 1.3.8
+      minimist: 1.2.8
+      strip-json-comments: 2.0.1
 
   react-dom@18.3.1(react@18.3.1):
     dependencies:
@@ -4123,6 +4339,12 @@ snapshots:
       js-yaml: 3.14.2
       pify: 4.0.1
       strip-bom: 3.0.0
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
 
   redent@3.0.0:
     dependencies:
@@ -4187,6 +4409,8 @@ snapshots:
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
+
+  safe-buffer@5.2.1: {}
 
   safer-buffer@2.1.2: {}
 
@@ -4269,6 +4493,14 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
+  simple-concat@1.0.1: {}
+
+  simple-get@4.0.1:
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
+
   sirv@3.0.2:
     dependencies:
       '@polka/url': 1.0.0-next.29
@@ -4296,6 +4528,10 @@ snapshots:
 
   string-argv@0.3.2: {}
 
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -4306,6 +4542,8 @@ snapshots:
     dependencies:
       min-indent: 1.0.1
 
+  strip-json-comments@2.0.1: {}
+
   strip-json-comments@3.1.1: {}
 
   supports-color@8.1.1:
@@ -4315,6 +4553,21 @@ snapshots:
   supports-preserve-symlinks-flag@1.0.0: {}
 
   symbol-tree@3.2.4: {}
+
+  tar-fs@2.1.4:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.4
+      tar-stream: 2.2.0
+
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
 
   term-size@2.2.1: {}
 
@@ -4360,6 +4613,10 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  tunnel-agent@0.6.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
   type-is@2.0.1:
     dependencies:
       content-type: 1.0.5
@@ -4391,6 +4648,8 @@ snapshots:
       browserslist: 4.28.1
       escalade: 3.2.0
       picocolors: 1.1.1
+
+  util-deprecate@1.0.2: {}
 
   vary@1.1.2: {}
 

--- a/server/admin.ts
+++ b/server/admin.ts
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+import { openKeyStore, type ApiKeyRecord } from './auth.js';
+
+/**
+ * Admin CLI for minting, listing, and revoking per-user API keys.
+ *
+ * Usage (on Fly):
+ *   fly ssh console -a lucent-mcp
+ *   node dist-server/server/admin.js mint alice@example.com
+ *   node dist-server/server/admin.js list
+ *   node dist-server/server/admin.js revoke alice@example.com
+ *
+ * Locally:
+ *   LUCENT_KEY_DB=./data/keys.db node dist-server/server/admin.js mint dev
+ */
+
+const DB_PATH = process.env['LUCENT_KEY_DB'] ?? './data/keys.db';
+
+function printHelp(): void {
+  process.stdout.write(
+    [
+      'lucent-mcp-admin — manage per-user API keys for the MCP server',
+      '',
+      'Commands:',
+      '  mint <label>             Mint a new key. Prints plaintext once — save it.',
+      '  list                     List all keys (masked). Shows active + revoked.',
+      '  revoke <label|prefix>    Revoke a live key by label or token hash prefix.',
+      '  help                     Show this message.',
+      '',
+      `Database: ${DB_PATH} (override with LUCENT_KEY_DB)`,
+      '',
+    ].join('\n'),
+  );
+}
+
+function fmtRow(r: ApiKeyRecord): string {
+  const state = r.revokedAt !== null ? `revoked ${r.revokedAt}` : 'active';
+  const lastUsed = r.lastUsedAt ?? 'never';
+  return [
+    `  #${r.id}`,
+    r.label.padEnd(24).slice(0, 24),
+    r.tokenHash.slice(0, 12) + '…',
+    `created ${r.createdAt}`,
+    `used ${lastUsed}`,
+    state,
+  ].join('  ');
+}
+
+function main(): number {
+  const [, , cmd, ...args] = process.argv;
+
+  if (cmd === undefined || cmd === 'help' || cmd === '--help' || cmd === '-h') {
+    printHelp();
+    return 0;
+  }
+
+  const store = openKeyStore(DB_PATH);
+  try {
+    switch (cmd) {
+      case 'mint': {
+        const label = args.join(' ').trim();
+        if (!label) {
+          process.stderr.write('error: mint requires a label\n');
+          return 2;
+        }
+        const { plaintext, record } = store.mint(label);
+        process.stdout.write(
+          [
+            `Minted key for "${record.label}" (id=${record.id}).`,
+            '',
+            'Plaintext (save this — it will not be shown again):',
+            '',
+            `  ${plaintext}`,
+            '',
+            'Give the bearer this key for use as `Authorization: Bearer <key>`.',
+            '',
+          ].join('\n'),
+        );
+        return 0;
+      }
+
+      case 'list': {
+        const rows = store.list();
+        if (rows.length === 0) {
+          process.stdout.write('No keys yet. Use `mint <label>` to create one.\n');
+          return 0;
+        }
+        process.stdout.write(`${rows.length} key(s):\n`);
+        for (const r of rows) process.stdout.write(fmtRow(r) + '\n');
+        return 0;
+      }
+
+      case 'revoke': {
+        const q = args.join(' ').trim();
+        if (!q) {
+          process.stderr.write('error: revoke requires a label or hash prefix\n');
+          return 2;
+        }
+        const revoked = store.revoke(q);
+        if (revoked === null) {
+          process.stderr.write(`No live key matches "${q}".\n`);
+          return 1;
+        }
+        process.stdout.write(
+          `Revoked "${revoked.label}" (id=${revoked.id}) at ${revoked.revokedAt}.\n`,
+        );
+        return 0;
+      }
+
+      default:
+        process.stderr.write(`error: unknown command "${cmd}"\n\n`);
+        printHelp();
+        return 2;
+    }
+  } catch (err) {
+    process.stderr.write(
+      `error: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    return 1;
+  } finally {
+    store.close();
+  }
+}
+
+process.exit(main());

--- a/server/auth.test.ts
+++ b/server/auth.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  getAuthContext,
+  hashKey,
+  openKeyStore,
+  runWithAuth,
+  type KeyStore,
+} from './auth.js';
+
+describe('KeyStore', () => {
+  let store: KeyStore;
+  const originalEnv = process.env['LUCENT_API_KEY'];
+
+  beforeEach(() => {
+    store = openKeyStore(':memory:');
+    delete process.env['LUCENT_API_KEY'];
+  });
+
+  afterEach(() => {
+    store.close();
+    if (originalEnv === undefined) delete process.env['LUCENT_API_KEY'];
+    else process.env['LUCENT_API_KEY'] = originalEnv;
+  });
+
+  it('mints a key with the lucent_beta_ prefix and unique hash', () => {
+    const { plaintext, record } = store.mint('alice@example.com');
+    expect(plaintext).toMatch(/^lucent_beta_[0-9a-f]{32}$/);
+    expect(record.label).toBe('alice@example.com');
+    expect(record.tokenHash).toBe(hashKey(plaintext));
+    expect(record.revokedAt).toBeNull();
+  });
+
+  it('authenticates a freshly-minted key and bumps last_used_at', () => {
+    const { plaintext, record } = store.mint('alice');
+    const ctx = store.authenticate(plaintext);
+    expect(ctx).not.toBeNull();
+    expect(ctx?.userId).toBe(String(record.id));
+    expect(ctx?.label).toBe('alice');
+
+    const [row] = store.list();
+    expect(row?.lastUsedAt).not.toBeNull();
+  });
+
+  it('rejects an unknown key', () => {
+    expect(store.authenticate('lucent_beta_deadbeef')).toBeNull();
+  });
+
+  it('rejects a key that does not start with the expected prefix', () => {
+    expect(store.authenticate('some-random-value')).toBeNull();
+  });
+
+  it('rejects a revoked key', () => {
+    const { plaintext } = store.mint('bob');
+    store.revoke('bob');
+    expect(store.authenticate(plaintext)).toBeNull();
+  });
+
+  it('revokes by label and by hash prefix', () => {
+    const { record: r1 } = store.mint('alice');
+    const { record: r2 } = store.mint('bob');
+
+    const revokedByLabel = store.revoke('alice');
+    expect(revokedByLabel?.id).toBe(r1.id);
+    expect(revokedByLabel?.revokedAt).not.toBeNull();
+
+    const revokedByPrefix = store.revoke(r2.tokenHash.slice(0, 8));
+    expect(revokedByPrefix?.id).toBe(r2.id);
+  });
+
+  it('returns null when revoking an unknown label', () => {
+    expect(store.revoke('nobody')).toBeNull();
+  });
+
+  it('throws when a prefix matches multiple live keys', () => {
+    // Mint two keys and force a collision by truncating to a deliberately
+    // short prefix that could match either hash.
+    store.mint('alice');
+    store.mint('bob');
+    // A 1-char hex prefix is almost certain to match both live rows.
+    expect(() => store.revoke('')).toThrow();
+  });
+
+  it('accepts the legacy LUCENT_API_KEY as a fallback', () => {
+    process.env['LUCENT_API_KEY'] = 'legacy-secret';
+    const ctx = store.authenticate('legacy-secret');
+    expect(ctx?.userId).toBe('legacy');
+    expect(ctx?.label).toBe('legacy');
+  });
+
+  it('ignores the legacy env var when it is unset', () => {
+    delete process.env['LUCENT_API_KEY'];
+    expect(store.authenticate('legacy-secret')).toBeNull();
+  });
+});
+
+describe('runWithAuth', () => {
+  it('exposes the active auth context to synchronous callers', () => {
+    const ctx = { userId: '1', label: 'alice', keyHashPrefix: 'abcd1234' };
+    const seen = runWithAuth(ctx, () => getAuthContext());
+    expect(seen).toEqual(ctx);
+  });
+
+  it('returns undefined outside of a runWithAuth scope', () => {
+    expect(getAuthContext()).toBeUndefined();
+  });
+});

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -1,0 +1,193 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { createHash, randomBytes, timingSafeEqual } from 'node:crypto';
+import { dirname } from 'node:path';
+import { mkdirSync } from 'node:fs';
+import Database from 'better-sqlite3';
+
+/**
+ * Per-user API key auth backed by SQLite.
+ *
+ * Keys are stored as sha256 hashes — the plaintext is shown once at mint time
+ * and never again. Bearer tokens presented on requests are hashed and looked
+ * up; matching rows have their `last_used_at` bumped so the admin CLI can tell
+ * who's actually active.
+ *
+ * A legacy `LUCENT_API_KEY` env var is still honored when set, to keep the
+ * first deploy working before the first DB key is minted. Unset it after
+ * cutover — see docs/MCP_HOSTING.md.
+ */
+
+const KEY_PREFIX = 'lucent_beta_';
+
+export interface ApiKeyRecord {
+  id: number;
+  label: string;
+  tokenHash: string;
+  createdAt: string;
+  revokedAt: string | null;
+  lastUsedAt: string | null;
+}
+
+export interface AuthContext {
+  /** DB row id, or "legacy" when authenticated via the env var fallback. */
+  userId: string;
+  /** Human-readable label ("rozina-admin") or "legacy" for env-var auth. */
+  label: string;
+  /** First 8 hex chars of sha256(key) — safe for logs. */
+  keyHashPrefix: string;
+}
+
+const authContext = new AsyncLocalStorage<AuthContext>();
+
+export function getAuthContext(): AuthContext | undefined {
+  return authContext.getStore();
+}
+
+export function runWithAuth<T>(ctx: AuthContext, fn: () => T): T {
+  return authContext.run(ctx, fn);
+}
+
+export function generateKey(): string {
+  return `${KEY_PREFIX}${randomBytes(16).toString('hex')}`;
+}
+
+export function hashKey(plaintext: string): string {
+  return createHash('sha256').update(plaintext).digest('hex');
+}
+
+function hashPrefix(fullHash: string): string {
+  return fullHash.slice(0, 8);
+}
+
+/**
+ * Constant-time compare of two equal-length strings. Used for the legacy env
+ * var fallback so we don't leak timing info about the shared key.
+ */
+function safeEqual(a: string, b: string): boolean {
+  const ab = Buffer.from(a);
+  const bb = Buffer.from(b);
+  if (ab.length !== bb.length) return false;
+  return timingSafeEqual(ab, bb);
+}
+
+export interface KeyStore {
+  mint(label: string): { plaintext: string; record: ApiKeyRecord };
+  list(): ApiKeyRecord[];
+  revoke(labelOrPrefix: string): ApiKeyRecord | null;
+  /** Returns the auth context if the bearer matches a live key, else null. */
+  authenticate(bearer: string): AuthContext | null;
+  close(): void;
+}
+
+interface DbRow {
+  id: number;
+  label: string;
+  token_hash: string;
+  created_at: string;
+  revoked_at: string | null;
+  last_used_at: string | null;
+}
+
+function rowToRecord(row: DbRow): ApiKeyRecord {
+  return {
+    id: row.id,
+    label: row.label,
+    tokenHash: row.token_hash,
+    createdAt: row.created_at,
+    revokedAt: row.revoked_at,
+    lastUsedAt: row.last_used_at,
+  };
+}
+
+export function openKeyStore(dbPath: string): KeyStore {
+  if (dbPath !== ':memory:') {
+    mkdirSync(dirname(dbPath), { recursive: true });
+  }
+
+  const db = new Database(dbPath);
+  db.pragma('journal_mode = WAL');
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS keys (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      label TEXT NOT NULL,
+      token_hash TEXT NOT NULL UNIQUE,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      revoked_at TEXT,
+      last_used_at TEXT
+    );
+    CREATE INDEX IF NOT EXISTS idx_keys_token_hash ON keys(token_hash);
+  `);
+
+  const insert = db.prepare(
+    'INSERT INTO keys (label, token_hash) VALUES (?, ?) RETURNING *',
+  );
+  const selectAll = db.prepare('SELECT * FROM keys ORDER BY id DESC');
+  const selectByHash = db.prepare('SELECT * FROM keys WHERE token_hash = ?');
+  const selectByLabelOrHashPrefix = db.prepare(
+    'SELECT * FROM keys WHERE label = ? OR token_hash LIKE ? LIMIT 2',
+  );
+  const bumpUsed = db.prepare(
+    "UPDATE keys SET last_used_at = datetime('now') WHERE id = ?",
+  );
+  const revoke = db.prepare(
+    "UPDATE keys SET revoked_at = datetime('now') WHERE id = ? RETURNING *",
+  );
+
+  return {
+    mint(label) {
+      if (!label.trim()) throw new Error('label must not be empty');
+      const plaintext = generateKey();
+      const row = insert.get(label.trim(), hashKey(plaintext)) as DbRow;
+      return { plaintext, record: rowToRecord(row) };
+    },
+
+    list() {
+      return (selectAll.all() as DbRow[]).map(rowToRecord);
+    },
+
+    revoke(labelOrPrefix) {
+      const rows = selectByLabelOrHashPrefix.all(
+        labelOrPrefix,
+        `${labelOrPrefix}%`,
+      ) as DbRow[];
+      const live = rows.filter((r) => r.revoked_at === null);
+      if (live.length === 0) return null;
+      if (live.length > 1) {
+        throw new Error(
+          `"${labelOrPrefix}" matches ${live.length} live keys — use a longer prefix or the exact label`,
+        );
+      }
+      const first = live[0];
+      if (first === undefined) return null;
+      const updated = revoke.get(first.id) as DbRow;
+      return rowToRecord(updated);
+    },
+
+    authenticate(bearer) {
+      const legacy = process.env['LUCENT_API_KEY'];
+      if (legacy !== undefined && legacy.length > 0 && safeEqual(bearer, legacy)) {
+        return {
+          userId: 'legacy',
+          label: 'legacy',
+          keyHashPrefix: hashPrefix(hashKey(bearer)),
+        };
+      }
+
+      if (!bearer.startsWith(KEY_PREFIX)) return null;
+      const hash = hashKey(bearer);
+      const row = selectByHash.get(hash) as DbRow | undefined;
+      if (row === undefined) return null;
+      if (row.revoked_at !== null) return null;
+      bumpUsed.run(row.id);
+      return {
+        userId: String(row.id),
+        label: row.label,
+        keyHashPrefix: hashPrefix(hash),
+      };
+    },
+
+    close() {
+      db.close();
+    },
+  };
+}

--- a/server/http.ts
+++ b/server/http.ts
@@ -5,6 +5,7 @@ import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 import { registerTools, DESIGN_RULES_SUMMARY } from './tools.js';
 import { getRecentCalls, subscribeToCalls, type StoredCall } from './logger.js';
+import { openKeyStore, runWithAuth, type AuthContext } from './auth.js';
 
 /** Compact summary of recent traffic for the dashboard's stat tiles and charts. */
 interface UsageAggregates {
@@ -44,8 +45,11 @@ function computeAggregates(calls: StoredCall[]): UsageAggregates {
 
 const PORT = Number(process.env['PORT'] ?? 3000);
 const HOST = process.env['HOST'] ?? '127.0.0.1';
-const API_KEY = process.env['LUCENT_API_KEY'];
+const LEGACY_KEY = process.env['LUCENT_API_KEY'];
 const MCP_PATH = process.env['LUCENT_MCP_PATH'] ?? '/mcp';
+const KEY_DB_PATH = process.env['LUCENT_KEY_DB'] ?? './data/keys.db';
+
+const keyStore = openKeyStore(KEY_DB_PATH);
 
 function log(msg: string): void {
   process.stderr.write(`[lucent-mcp-http] ${msg}\n`);
@@ -96,12 +100,17 @@ function jsonRpcError(
   });
 }
 
-function checkAuth(req: IncomingMessage): boolean {
-  if (!API_KEY) return true; // Auth disabled when env var is not set
+function extractBearer(req: IncomingMessage): string | null {
   const header = req.headers['authorization'];
-  if (typeof header !== 'string') return false;
+  if (typeof header !== 'string') return null;
   const match = header.match(/^Bearer\s+(.+)$/i);
-  return match !== null && match[1] === API_KEY;
+  return match !== null && match[1] !== undefined ? match[1] : null;
+}
+
+function authenticate(req: IncomingMessage): AuthContext | null {
+  const bearer = extractBearer(req);
+  if (bearer === null) return null;
+  return keyStore.authenticate(bearer);
 }
 
 function setCorsHeaders(res: ServerResponse): void {
@@ -133,7 +142,7 @@ const httpServer = createServer(async (req, res) => {
 
   // Usage snapshot — recent calls + aggregates for the dashboard.
   if (url.pathname === '/usage' && req.method === 'GET') {
-    if (!checkAuth(req)) {
+    if (authenticate(req) === null) {
       res.setHeader('WWW-Authenticate', 'Bearer');
       writeJson(res, 401, { error: 'Unauthorized' });
       return;
@@ -148,7 +157,7 @@ const httpServer = createServer(async (req, res) => {
 
   // Usage live stream — SSE, pushes each new tool call as it happens.
   if (url.pathname === '/usage/stream' && req.method === 'GET') {
-    if (!checkAuth(req)) {
+    if (authenticate(req) === null) {
       res.setHeader('WWW-Authenticate', 'Bearer');
       writeJson(res, 401, { error: 'Unauthorized' });
       return;
@@ -180,7 +189,8 @@ const httpServer = createServer(async (req, res) => {
     return;
   }
 
-  if (!checkAuth(req)) {
+  const authCtx = authenticate(req);
+  if (authCtx === null) {
     res.setHeader('WWW-Authenticate', 'Bearer');
     writeJson(res, 401, { error: 'Unauthorized' });
     return;
@@ -203,7 +213,8 @@ const httpServer = createServer(async (req, res) => {
       void transport.close();
       void server.close();
     });
-    await transport.handleRequest(req, res, body);
+    // Propagate the authenticated identity to tool handlers + the logger.
+    await runWithAuth(authCtx, () => transport.handleRequest(req, res, body));
   } catch (err) {
     log(`error handling request: ${(err as Error).message}`);
     if (!res.headersSent) {
@@ -214,11 +225,12 @@ const httpServer = createServer(async (req, res) => {
 
 httpServer.listen(PORT, HOST, () => {
   log(`listening on http://${HOST}:${PORT}${MCP_PATH}`);
-  if (!API_KEY) {
-    log('WARNING: LUCENT_API_KEY is not set — the server is unauthenticated.');
+  log(`key store: ${KEY_DB_PATH}`);
+  if (LEGACY_KEY !== undefined) {
+    log('note: LUCENT_API_KEY (legacy) is set and will be accepted as a fallback. Unset it once a DB key is minted.');
   }
   if (HOST === '0.0.0.0' || HOST === '::') {
-    log(`WARNING: bound to ${HOST}. Set LUCENT_API_KEY before exposing publicly.`);
+    log(`WARNING: bound to ${HOST}. Ensure at least one DB key is minted before exposing publicly.`);
   }
 });
 

--- a/server/logger.ts
+++ b/server/logger.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'node:crypto';
+import { getAuthContext } from './auth.js';
 
 /**
  * Structured logging + in-memory ring buffer for MCP tool calls.
@@ -10,21 +10,12 @@ import { createHash } from 'node:crypto';
  * Set `LUCENT_MCP_QUIET=1` to silence stderr — the ring buffer still fills,
  * so the usage dashboard keeps working.
  *
- * When `LUCENT_API_KEY` is set, a short sha256 prefix of the key is included
- * in log entries for usage analytics. The raw key is never logged.
+ * When called inside an authenticated HTTP request, the caller's key hash
+ * prefix and label are included so usage can be attributed per user.
  */
 
 const QUIET = process.env['LUCENT_MCP_QUIET'] === '1';
 const BUFFER_SIZE = 500;
-
-/**
- * Returns the first 8 hex chars of sha256(key). Short enough to stay readable
- * in logs, safe to leak (pre-image resistant), and unique enough to distinguish
- * customers once multi-key auth lands (see issue #15).
- */
-function hashKeyPrefix(key: string): string {
-  return createHash('sha256').update(key).digest('hex').slice(0, 8);
-}
 
 export interface ToolCallLogEntry {
   tool: string;
@@ -34,10 +25,13 @@ export interface ToolCallLogEntry {
   error?: string;
 }
 
-/** An entry as stored in the ring buffer (with the computed timestamp + key hash). */
+/** An entry as stored in the ring buffer (with timestamp + key/user attribution). */
 export interface StoredCall extends ToolCallLogEntry {
   t: string;
+  /** First 8 hex chars of sha256(key) — safe for logs. */
   key?: string;
+  /** Human-readable label from the key record ("alice@example.com"). */
+  user?: string;
 }
 
 // ─── Ring buffer + subscribers ───────────────────────────────────────────────
@@ -65,7 +59,7 @@ export function subscribeToCalls(fn: Subscriber): () => void {
 // ─── Logging ─────────────────────────────────────────────────────────────────
 
 export function logToolCall(entry: ToolCallLogEntry): void {
-  const apiKey = process.env['LUCENT_API_KEY'];
+  const auth = getAuthContext();
   const stored: StoredCall = {
     t: new Date().toISOString(),
     tool: entry.tool,
@@ -73,7 +67,7 @@ export function logToolCall(entry: ToolCallLogEntry): void {
     durationMs: entry.durationMs,
     ok: entry.ok,
     ...(entry.error !== undefined && { error: entry.error }),
-    ...(apiKey !== undefined && { key: hashKeyPrefix(apiKey) }),
+    ...(auth !== undefined && { key: auth.keyHashPrefix, user: auth.label }),
   };
 
   // 1. Push to ring buffer (always, even in QUIET mode — dashboards still work).


### PR DESCRIPTION
## Summary

Swaps the single shared `LUCENT_API_KEY` for SQLite-backed per-user API keys so you can mint, track, and revoke beta users individually (and bulk-revoke everyone when beta ends). Carved out of #15 — stripe/billing stays out of scope.

- [server/auth.ts](server/auth.ts) — SQLite-backed `KeyStore` (sha256-hashed tokens, soft-delete on revoke, bumps `last_used_at` on every successful auth). Auth context is stashed in `AsyncLocalStorage` so the existing tool-call logger can attribute each call to the minting label without threading context through every handler.
- [server/admin.ts](server/admin.ts) — new `lucent-mcp-admin` CLI with `mint <label>` / `list` / `revoke <label|prefix>`. Plaintext is printed once at mint time and never again.
- [server/http.ts](server/http.ts) — `checkAuth` swapped for `keyStore.authenticate(bearer)`. The authenticated request is wrapped in `runWithAuth` before handing off to the MCP SDK transport, so logs show `"user": "alice@example.com"` for every tool call.
- [server/logger.ts](server/logger.ts) — reads from `AuthContext` instead of hashing `process.env.LUCENT_API_KEY`; `StoredCall` gains a `user` field.
- [fly.toml](fly.toml) — mounts a Fly volume at `/data`, sets `LUCENT_KEY_DB=/data/keys.db`.
- [Dockerfile](Dockerfile) — adds `python3 make g++` to the builder stage (node-gyp fallback for `better-sqlite3`), prunes dev deps before copying `node_modules` to the lean runtime image.
- [docs/MCP_HOSTING.md](docs/MCP_HOSTING.md) — first-deploy section now includes `fly volumes create`, plus mint/list/revoke/bulk-revoke recipes and the legacy-cutover flow.
- [server/auth.test.ts](server/auth.test.ts) — 12 unit tests covering mint, auth, revoke, prefix ambiguity, legacy fallback, and the `AsyncLocalStorage` context propagation.

## Deploy plan (for after merge)

1. `fly volumes create lucent_mcp_data --app lucent-mcp --region iad --size 1`
2. `fly deploy --app lucent-mcp` — both legacy `LUCENT_API_KEY` **and** the DB work at this point; DB starts empty, so only legacy authenticates.
3. `fly ssh console --app lucent-mcp` → `node dist-server/server/admin.js mint rozina-admin` → save the plaintext key.
4. Smoke-test the new key against `https://mcp.lucentui.ai/mcp` before flipping.
5. `fly secrets unset LUCENT_API_KEY --app lucent-mcp` — now only DB keys authenticate.
6. Mint a key per beta user; hand out via your preferred channel.

## Out of scope

- Stripe / self-serve signup / billing — stays on #15.
- Rate limits / quotas per key — can come once we have real usage data.

## Test plan

- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm test` — 266 tests pass (12 new in `server/auth.test.ts`)
- [x] Local smoke: mint a key, unauthed POST → 401, authed POST → 200 + full tools list, revoke → same key now 401
- [x] `list` shows `used 2026-04-14 …` after a successful call, `revoked 2026-04-14 …` after revocation
- [ ] CI green on this PR
- [ ] Post-merge: `fly deploy` on the Alpine builder — verify `better-sqlite3` prebuild resolves (or falls back to the gcc toolchain we added); verify the volume mounts and the DB persists across `fly deploy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)