### PR TITLE
docs: beta quickstart for MCP client setup (#152)

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,9 +162,9 @@ Connect Lucent UI's manifest layer to your AI coding tool. The server exposes th
 node dist-server/server/index.js
 ```
 
-### Hosted HTTP endpoint
+### Hosted HTTP endpoint (beta)
 
-For clients that support remote MCP, the server is also available over HTTP at `https://mcp.lucentui.ai/mcp` (bearer-token auth via `LUCENT_API_KEY`). See [`docs/MCP_HOSTING.md`](docs/MCP_HOSTING.md) for the Fly.io deploy flow, key rotation, and the local `cloudflared` fallback.
+The server is live at `https://mcp.lucentui.ai/mcp` with per-user bearer-token auth. Beta users: see [`docs/BETA_QUICKSTART.md`](docs/BETA_QUICKSTART.md) for how to request a key and configure your MCP client. Operators: see [`docs/MCP_HOSTING.md`](docs/MCP_HOSTING.md) for the Fly.io deploy and key-management flow.
 
 ---
 

--- a/docs/BETA_QUICKSTART.md
+++ b/docs/BETA_QUICKSTART.md
@@ -1,0 +1,111 @@
+# Lucent UI beta quickstart
+
+Welcome to the Lucent UI private beta. This page takes you from zero to "my AI assistant knows about Lucent components" in under 10 minutes.
+
+**What you get as a beta user:** a personal API key for the Lucent MCP server at `https://mcp.lucentui.ai/mcp`. Your AI assistant (Claude Desktop, Cursor, or any MCP-compatible client) connects to it and gains tools for looking up component manifests, design presets, and composition patterns — so it writes Lucent UI code that actually matches the library, instead of hallucinating props.
+
+---
+
+## 1. Request your key
+
+Beta keys are issued by hand. DM us (Slack / email / wherever you normally reach us) with:
+
+- Your name
+- The project you're planning to use Lucent UI in (one sentence is fine)
+
+We'll reply with a single-view [onetimesecret.com](https://onetimesecret.com) link that contains your key. The link self-destructs after you open it — save the key to your password manager immediately, because we can't re-show it.
+
+Your key looks like `lucent_beta_` followed by 32 hex characters.
+
+---
+
+## 2. Configure your MCP client
+
+Pick whichever client you already use. The config is the same shape in all of them: a bearer token against our HTTPS endpoint.
+
+> **Heads up:** this is a **remote HTTP MCP** server. Older MCP clients that only speak stdio (local-process only) won't work directly — you'd need a local bridge, which is out of scope for beta. Claude Desktop ≥ Nov 2025 and Cursor ≥ 0.44 both support remote HTTP natively.
+
+### Claude Desktop
+
+Edit `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows):
+
+```json
+{
+  "mcpServers": {
+    "lucent-ui": {
+      "type": "http",
+      "url": "https://mcp.lucentui.ai/mcp",
+      "headers": {
+        "Authorization": "Bearer lucent_beta_your_key_here"
+      }
+    }
+  }
+}
+```
+
+Fully quit and reopen Claude Desktop. The Lucent tools should show up in the tools picker in the chat UI.
+
+### Cursor
+
+Edit `.cursor/mcp.json` at your project root (or `~/.cursor/mcp.json` for all projects):
+
+```json
+{
+  "mcpServers": {
+    "lucent-ui": {
+      "url": "https://mcp.lucentui.ai/mcp",
+      "headers": {
+        "Authorization": "Bearer lucent_beta_your_key_here"
+      }
+    }
+  }
+}
+```
+
+Restart Cursor, then open Settings → MCP and confirm `lucent-ui` shows a green status.
+
+### Other clients
+
+Any MCP client that supports the [Streamable HTTP transport](https://modelcontextprotocol.io/docs/concepts/transports#streamable-http) will work — URL + bearer token are all you need. If your client has its own config format, replicate the same two fields (`url`, `Authorization: Bearer …`).
+
+---
+
+## 3. Make your first call
+
+In your AI assistant, ask something like:
+
+> Using lucent-ui, give me a Button component with a loading spinner. Use the real prop names.
+
+Behind the scenes the assistant will call the Lucent tool `get_component_manifest("Button")`, read the actual prop list, and write code that matches. You can also try:
+
+- "What composition patterns does Lucent UI have for dashboards?" → `search_components` / `get_composition_pattern`
+- "Generate a LucentProvider config for a modern emerald theme." → `get_preset_config`
+- "What spacing rules does Lucent UI use?" → `get_design_rules`
+
+If the assistant's code uses props that are actually in the manifest, you're good.
+
+---
+
+## 4. Troubleshooting
+
+**`401 Unauthorized`** — The bearer token is missing, wrong, or revoked. Double-check the `Authorization` header matches the key you got verbatim (including the `lucent_beta_` prefix). If you think it was revoked by mistake, ping us.
+
+**`404 Not Found` or "connection refused"** — You're probably hitting the wrong URL. The path is `/mcp` (not `/` or `/v1/mcp`), and the hostname is `mcp.lucentui.ai` (not `.com`).
+
+**Client says "MCP server not supported" or only accepts a `command`/`args` config** — Your client is on an older version that only speaks stdio. Update it. If you can't, tell us and we'll look at a bridge as a followup.
+
+**Tools show up but every call errors** — Usually a stale config. Fully quit and relaunch the client (not just close the window). On macOS, `⌘Q` the app, then reopen.
+
+---
+
+## 5. Feedback
+
+This is a beta — we actively want rough edges in writing.
+
+- **Bugs or broken tools:** [open an issue](https://github.com/rozina-hudson/lucent-ui/issues/new?labels=beta) and apply the `beta` label.
+- **Feature requests / missing components:** same issue tracker, or reply on whatever channel we used to send you the key.
+- **"This crashed / hung / timed out":** include the tool name, the parameters you passed, and (if you have it) the `fly-request-id` from the response headers.
+
+We watch `last_used_at` on every key, so we can tell who's actually exercising the server — if something breaks and you fall silent, we'll reach out.
+
+Thank you for beta-testing.


### PR DESCRIPTION
## Summary

Adds the onboarding page we hand to every beta user: [docs/BETA_QUICKSTART.md](docs/BETA_QUICKSTART.md).

Flow it documents:

1. **Request a key** — DM / email → we reply with a [onetimesecret.com](https://onetimesecret.com) single-view link.
2. **Configure the MCP client** — Claude Desktop (`claude_desktop_config.json`) and Cursor (`.cursor/mcp.json`) config snippets using the remote HTTP transport, bearer-token auth, and the `mcp.lucentui.ai` hostname. Notes that stdio-only clients are out of scope.
3. **First call** — a few example prompts that exercise `get_component_manifest`, `search_components`, `get_composition_pattern`, `get_preset_config`, `get_design_rules`.
4. **Troubleshooting** — the three failure modes we expect beta users to hit (401, wrong URL, client too old / stdio-only) plus the "fully quit the client" fix for stale config.
5. **Feedback** — GitHub Issues with the new `beta` label, plus a note that we watch `last_used_at` so silent churn gets a nudge.

Also:

- Links the quickstart from the README's "Hosted HTTP endpoint (beta)" section so it's one click from the landing README.
- Creates a `beta` label on the repo (already done via `gh label create`).

Closes #152.

## Test plan

- [x] Rendered doc reads cleanly, no broken internal links.
- [ ] Walk one real beta user through the doc end-to-end — first touchpoint where gaps will show.
- [ ] If Claude Desktop or Cursor's config shape changes before the beta, revisit the snippets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)