### PR TITLE
feat: Combobox atom — searchable form-field autocomplete

### DIFF
--- a/dev/ComponentPreview.tsx
+++ b/dev/ComponentPreview.tsx
@@ -22,6 +22,7 @@ import { Checkbox } from '../src/components/atoms/Checkbox/index.js';
 import { Radio, RadioGroup } from '../src/components/atoms/Radio/index.js';
 import { Toggle } from '../src/components/atoms/Toggle/index.js';
 import { Select } from '../src/components/atoms/Select/index.js';
+import { Combobox } from '../src/components/atoms/Combobox/index.js';
 import { Tag } from '../src/components/atoms/Tag/index.js';
 import { Tooltip } from '../src/components/atoms/Tooltip/index.js';
 import { Icon } from '../src/components/atoms/Icon/index.js';
@@ -301,7 +302,7 @@ function Inner({
 
   const sectionGroups: Record<string, { label: string; tier: 'atom' | 'molecule' | 'pattern' | 'composition'; items: string[] }> = {
     buttons:     { label: 'Buttons & Actions', tier: 'atom', items: ['Button', 'SplitButton', 'ButtonGroup', 'Toggle', 'SegmentedControl'] },
-    inputs:      { label: 'Input Fields',      tier: 'atom', items: ['Input', 'Textarea', 'Select', 'Checkbox', 'Radio', 'Slider', 'ColorPicker', 'ColorSwatch'] },
+    inputs:      { label: 'Input Fields',      tier: 'atom', items: ['Input', 'Textarea', 'Select', 'Combobox', 'Checkbox', 'Radio', 'Slider', 'ColorPicker', 'ColorSwatch'] },
     text:        { label: 'Text & Labels',      tier: 'atom', items: ['Text', 'Badge', 'Chip', 'Tag', 'Icon', 'Tooltip', 'CodeBlock'] },
     media:       { label: 'Media & Status',     tier: 'atom', items: ['Avatar', 'Spinner', 'Progress', 'Divider'] },
     layout:      { label: 'Layout',             tier: 'atom', items: ['Stack', 'Row', 'Table'] },
@@ -344,6 +345,7 @@ function Inner({
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [selectVal, setSelectVal] = useState('');
+  const [comboboxVal, setComboboxVal] = useState('America/New_York');
   const [tags, setTags] = useState(['React', 'TypeScript', 'Design Systems']);
   const [searchQuery, setSearchQuery] = useState('');
   const [filterQuery, setFilterQuery] = useState('');
@@ -1690,6 +1692,118 @@ function Inner({
               placeholder="Select a role"
               options={[{ value: 'admin', label: 'Admin' }, { value: 'member', label: 'Member' }]}
               errorText="Please select a role to continue"
+            />
+          </div>
+        </Row>
+      </Section>
+
+      {/* Combobox */}
+      <Section title="Combobox" tokens={tokens} hidden={!showSection('Combobox')}>
+        <Row label="Timezone picker (with hints)" tokens={tokens}>
+          <div style={{ width: 320 }}>
+            <Combobox
+              label="Timezone"
+              placeholder="Search timezones…"
+              options={[
+                { value: 'America/Los_Angeles', label: 'America/Los_Angeles', hint: 'UTC-08:00' },
+                { value: 'America/Denver',      label: 'America/Denver',      hint: 'UTC-07:00' },
+                { value: 'America/Chicago',     label: 'America/Chicago',     hint: 'UTC-06:00' },
+                { value: 'America/New_York',    label: 'America/New_York',    hint: 'UTC-05:00' },
+                { value: 'Europe/London',       label: 'Europe/London',       hint: 'UTC+00:00' },
+                { value: 'Europe/Paris',        label: 'Europe/Paris',        hint: 'UTC+01:00' },
+                { value: 'Europe/Berlin',       label: 'Europe/Berlin',       hint: 'UTC+01:00' },
+                { value: 'Asia/Dubai',          label: 'Asia/Dubai',          hint: 'UTC+04:00' },
+                { value: 'Asia/Kolkata',        label: 'Asia/Kolkata',        hint: 'UTC+05:30' },
+                { value: 'Asia/Shanghai',       label: 'Asia/Shanghai',       hint: 'UTC+08:00' },
+                { value: 'Asia/Tokyo',          label: 'Asia/Tokyo',          hint: 'UTC+09:00' },
+                { value: 'Australia/Sydney',    label: 'Australia/Sydney',    hint: 'UTC+10:00' },
+              ]}
+              value={comboboxVal}
+              onChange={setComboboxVal}
+            />
+          </div>
+        </Row>
+        <Row label="Sizes" tokens={tokens}>
+          {(['sm', 'md', 'lg'] as const).map(s => (
+            <div key={s} style={{ width: 220 }}>
+              <Combobox
+                size={s}
+                placeholder={`Size ${s}`}
+                options={[
+                  { value: 'react', label: 'React' },
+                  { value: 'vue',   label: 'Vue' },
+                  { value: 'svelte', label: 'Svelte' },
+                  { value: 'solid', label: 'Solid' },
+                ]}
+                defaultValue="react"
+              />
+            </div>
+          ))}
+        </Row>
+        <Row label="Grouped" tokens={tokens}>
+          <div style={{ width: 280 }}>
+            <Combobox
+              label="Currency"
+              placeholder="Choose a currency"
+              options={[
+                { value: 'usd', label: 'US Dollar',     hint: 'USD', group: 'Americas' },
+                { value: 'cad', label: 'CA Dollar',     hint: 'CAD', group: 'Americas' },
+                { value: 'brl', label: 'Brazilian Real', hint: 'BRL', group: 'Americas' },
+                { value: 'eur', label: 'Euro',          hint: 'EUR', group: 'Europe' },
+                { value: 'gbp', label: 'British Pound', hint: 'GBP', group: 'Europe' },
+                { value: 'jpy', label: 'Japanese Yen',  hint: 'JPY', group: 'Asia' },
+                { value: 'cny', label: 'Chinese Yuan',  hint: 'CNY', group: 'Asia' },
+              ]}
+            />
+          </div>
+        </Row>
+        <Row label="With helper" tokens={tokens}>
+          <div style={{ width: 280 }}>
+            <Combobox
+              label="Assignee"
+              placeholder="Search team…"
+              helperText="Required"
+              options={[
+                { value: 'a', label: 'Ada Lovelace' },
+                { value: 'g', label: 'Grace Hopper' },
+                { value: 'm', label: 'Margaret Hamilton' },
+                { value: 'k', label: 'Katherine Johnson' },
+              ]}
+            />
+          </div>
+        </Row>
+        <Row label="With error" tokens={tokens}>
+          <div style={{ width: 280 }}>
+            <Combobox
+              label="Role"
+              placeholder="Select a role"
+              errorText="Please pick a role to continue"
+              options={[{ value: 'admin', label: 'Admin' }, { value: 'member', label: 'Member' }]}
+            />
+          </div>
+        </Row>
+        <Row label="Free-form (allowCustomValue)" tokens={tokens}>
+          <div style={{ width: 280 }}>
+            <Combobox
+              label="Tag"
+              placeholder="Pick or type a tag"
+              helperText="Type to create a new tag"
+              allowCustomValue
+              options={[
+                { value: 'design',     label: 'design' },
+                { value: 'engineering', label: 'engineering' },
+                { value: 'marketing',  label: 'marketing' },
+              ]}
+            />
+          </div>
+        </Row>
+        <Row label="Disabled" tokens={tokens}>
+          <div style={{ width: 280 }}>
+            <Combobox
+              label="Locked field"
+              disabled
+              defaultValue="en"
+              options={[{ value: 'en', label: 'English' }, { value: 'fr', label: 'French' }]}
             />
           </div>
         </Row>

--- a/server/registry.ts
+++ b/server/registry.ts
@@ -11,6 +11,7 @@ import { COMPONENT_MANIFEST as Icon } from '../src/components/atoms/Icon/Icon.ma
 import { COMPONENT_MANIFEST as Input } from '../src/components/atoms/Input/Input.manifest.js';
 import { COMPONENT_MANIFEST as Radio } from '../src/components/atoms/Radio/Radio.manifest.js';
 import { COMPONENT_MANIFEST as Select } from '../src/components/atoms/Select/Select.manifest.js';
+import { COMPONENT_MANIFEST as Combobox } from '../src/components/atoms/Combobox/Combobox.manifest.js';
 import { COMPONENT_MANIFEST as Spinner } from '../src/components/atoms/Spinner/Spinner.manifest.js';
 import { COMPONENT_MANIFEST as Tag } from '../src/components/atoms/Tag/Tag.manifest.js';
 import { COMPONENT_MANIFEST as Text } from '../src/components/atoms/Text/Text.manifest.js';
@@ -42,6 +43,7 @@ export const ALL_MANIFESTS: ComponentManifest[] = [
   Input,
   Radio,
   Select,
+  Combobox,
   Spinner,
   Tag,
   Text,

--- a/src/components/atoms/Combobox/Combobox.manifest.ts
+++ b/src/components/atoms/Combobox/Combobox.manifest.ts
@@ -1,0 +1,216 @@
+import type { ComponentManifest } from '../../../manifest/types.js';
+
+export const COMPONENT_MANIFEST: ComponentManifest = {
+  id: 'combobox',
+  name: 'Combobox',
+  tier: 'atom',
+  domain: 'neutral',
+  specVersion: '0.1',
+
+  description:
+    'A searchable single-select form field — type to filter, Enter to commit a value from a known option set.',
+
+  designIntent:
+    'Combobox fills the gap between Select (native dropdown, no search — unusable past ~15 options) ' +
+    'and FilterSelect (filter-bar pill, wrong chrome for forms). Use it anywhere a Select would feel ' +
+    'too long to scan: timezones, country pickers, currencies, long taxonomies. Visually it mirrors ' +
+    'Input so it drops into FormField cleanly alongside other form controls. ' +
+    'Typing filters the option list (case-insensitive match on label and hint). Enter commits the ' +
+    'highlighted match; Escape reverts to the previously committed value without changes. Options ' +
+    'support a secondary `hint` (e.g. "UTC-05:00") and can be grouped via `group`. ' +
+    'By default only values that exist in `options` can be committed — pair with `allowCustomValue` ' +
+    'for free-form text with autocomplete suggestions (e.g. tag input).',
+
+  props: [
+    {
+      name: 'options',
+      type: 'array',
+      required: true,
+      description: 'Array of { value, label, hint?, group?, disabled? } option objects.',
+    },
+    {
+      name: 'value',
+      type: 'string',
+      required: false,
+      description: 'Controlled selected value. Pair with onChange.',
+    },
+    {
+      name: 'defaultValue',
+      type: 'string',
+      required: false,
+      description: 'Initial selected value in uncontrolled mode.',
+    },
+    {
+      name: 'onChange',
+      type: 'function',
+      required: false,
+      description: 'Called with the new value when a commit happens (click, Enter, or Tab on match).',
+    },
+    {
+      name: 'placeholder',
+      type: 'string',
+      required: false,
+      description: 'Placeholder shown when no value is selected.',
+    },
+    {
+      name: 'label',
+      type: 'string',
+      required: false,
+      description: 'Visible label rendered above the field. Omit if wrapping in FormField.',
+    },
+    {
+      name: 'helperText',
+      type: 'string',
+      required: false,
+      description: 'Supplementary hint rendered below the field.',
+    },
+    {
+      name: 'errorText',
+      type: 'string',
+      required: false,
+      description: 'Validation error message. Replaces helperText and applies error styling.',
+    },
+    {
+      name: 'size',
+      type: 'enum',
+      required: false,
+      default: 'md',
+      description: 'Field height — matches Input at each tier.',
+      enumValues: ['sm', 'md', 'lg'],
+    },
+    {
+      name: 'disabled',
+      type: 'boolean',
+      required: false,
+      default: 'false',
+      description: 'Prevents interaction.',
+    },
+    {
+      name: 'allowCustomValue',
+      type: 'boolean',
+      required: false,
+      default: 'false',
+      description:
+        'When true, committing a query that does not match any option passes the raw text to onChange. ' +
+        'Use for free-form text with autocomplete suggestions.',
+    },
+    {
+      name: 'emptyMessage',
+      type: 'ReactNode',
+      required: false,
+      default: '"No matches"',
+      description: 'Content shown inside the dropdown when no options match the query.',
+    },
+    {
+      name: 'id',
+      type: 'string',
+      required: false,
+      description: 'Input id for label association. Auto-generated when omitted.',
+    },
+    {
+      name: 'name',
+      type: 'string',
+      required: false,
+      description: 'Form field name.',
+    },
+  ],
+
+  usageExamples: [
+    {
+      title: 'Uncontrolled',
+      code: `
+<Combobox
+  label="Framework"
+  placeholder="Search frameworks…"
+  options={[
+    { value: 'react',  label: 'React' },
+    { value: 'vue',    label: 'Vue' },
+    { value: 'svelte', label: 'Svelte' },
+    { value: 'solid',  label: 'Solid' },
+  ]}
+  defaultValue="react"
+/>`.trim(),
+    },
+    {
+      title: 'Controlled with hints (timezone picker)',
+      code: `
+const [tz, setTz] = useState('America/New_York');
+
+<Combobox
+  label="Timezone"
+  placeholder="Search timezones…"
+  options={[
+    { value: 'America/New_York',    label: 'America/New_York',    hint: 'UTC-05:00' },
+    { value: 'Europe/London',       label: 'Europe/London',       hint: 'UTC+00:00' },
+    { value: 'Asia/Tokyo',          label: 'Asia/Tokyo',          hint: 'UTC+09:00' },
+  ]}
+  value={tz}
+  onChange={setTz}
+/>`.trim(),
+    },
+    {
+      title: 'Grouped options',
+      code: `
+<Combobox
+  label="Currency"
+  options={[
+    { value: 'usd', label: 'US Dollar',    hint: 'USD', group: 'Americas' },
+    { value: 'cad', label: 'CA Dollar',    hint: 'CAD', group: 'Americas' },
+    { value: 'eur', label: 'Euro',         hint: 'EUR', group: 'Europe' },
+    { value: 'gbp', label: 'British Pound', hint: 'GBP', group: 'Europe' },
+  ]}
+/>`.trim(),
+    },
+    {
+      title: 'Inside FormField',
+      code: `
+<FormField label="Assignee" htmlFor="assignee" helperText="Required">
+  <Combobox id="assignee" options={users} value={assignee} onChange={setAssignee} />
+</FormField>`.trim(),
+    },
+    {
+      title: 'Free-form with suggestions',
+      code: `
+<Combobox
+  label="Tag"
+  allowCustomValue
+  options={existingTags}
+  value={tag}
+  onChange={setTag}
+  placeholder="Pick or type a tag"
+/>`.trim(),
+    },
+    {
+      title: 'With validation error',
+      code: `<Combobox label="Country" options={countries} errorText="Please select a country" />`,
+    },
+  ],
+
+  compositionGraph: [],
+
+  accessibility: {
+    role: 'combobox',
+    ariaAttributes: [
+      'aria-autocomplete="list"',
+      'aria-expanded',
+      'aria-controls',
+      'aria-activedescendant',
+      'aria-invalid',
+      'aria-describedby',
+    ],
+    keyboardInteractions: [
+      'Type — filters the option list',
+      'ArrowDown — open dropdown / move to next enabled option',
+      'ArrowUp — move to previous enabled option',
+      'Home / End — jump to first / last option',
+      'Enter — commit the highlighted option (or the typed value when allowCustomValue is true)',
+      'Tab — commit highlighted match if query is present, then move focus',
+      'Escape — close the dropdown without committing',
+    ],
+    notes:
+      'Follows the WAI-ARIA 1.2 combobox pattern (list autocomplete with manual selection). ' +
+      'The listbox renders via portal and is linked to the input with aria-controls. ' +
+      'The currently highlighted option is reflected by aria-activedescendant so screen readers ' +
+      'announce it without moving DOM focus from the input.',
+  },
+};

--- a/src/components/atoms/Combobox/Combobox.tsx
+++ b/src/components/atoms/Combobox/Combobox.tsx
@@ -1,0 +1,514 @@
+import {
+  useState, useRef, useEffect, useLayoutEffect, useId,
+  type CSSProperties, type KeyboardEvent, type ReactNode,
+} from 'react';
+import { createPortal } from 'react-dom';
+
+export interface ComboboxOption {
+  value: string;
+  label: string;
+  /** Secondary text shown on the right of the option (e.g. "UTC-05:00") */
+  hint?: string;
+  /** Optional group heading — consecutive options sharing a group render under one header */
+  group?: string;
+  disabled?: boolean;
+}
+
+export type ComboboxSize = 'sm' | 'md' | 'lg';
+
+export interface ComboboxProps {
+  options: ComboboxOption[];
+  value?: string;
+  defaultValue?: string;
+  onChange?: (value: string) => void;
+  placeholder?: string;
+  disabled?: boolean;
+  size?: ComboboxSize;
+  label?: string;
+  helperText?: string;
+  errorText?: string;
+  /** Message shown when no options match the query. Default: "No matches" */
+  emptyMessage?: ReactNode;
+  /** When true, committing a value not in `options` is allowed and the raw query is passed to onChange. */
+  allowCustomValue?: boolean;
+  id?: string;
+  name?: string;
+  autoFocus?: boolean;
+  style?: CSSProperties;
+  'aria-label'?: string;
+}
+
+const sizeH: Record<ComboboxSize, string> = {
+  sm: 'calc(var(--lucent-space-8) * 0.5 + 16px)',
+  md: 'calc(var(--lucent-space-10) * 0.5 + 20px)',
+  lg: 'calc(var(--lucent-space-12) * 0.5 + 24px)',
+};
+const sizeFont: Record<ComboboxSize, string> = {
+  sm: 'var(--lucent-font-size-sm)',
+  md: 'var(--lucent-font-size-md)',
+  lg: 'var(--lucent-font-size-md)',
+};
+const sizeLabelFont: Record<ComboboxSize, string> = {
+  sm: 'var(--lucent-font-size-sm)',
+  md: 'var(--lucent-font-size-sm)',
+  lg: 'var(--lucent-font-size-md)',
+};
+const sizePx: Record<ComboboxSize, string> = {
+  sm: 'var(--lucent-space-3)',
+  md: 'var(--lucent-space-4)',
+  lg: 'var(--lucent-space-4)',
+};
+const dropdownPadding: Record<ComboboxSize, string> = {
+  sm: 'var(--lucent-space-2)',
+  md: 'var(--lucent-space-2)',
+  lg: 'var(--lucent-space-3)',
+};
+const hintFont: Record<ComboboxSize, string> = {
+  sm: 'var(--lucent-font-size-xs)',
+  md: 'var(--lucent-font-size-sm)',
+  lg: 'var(--lucent-font-size-sm)',
+};
+
+export function Combobox({
+  options,
+  value: controlledValue,
+  defaultValue = '',
+  onChange,
+  placeholder,
+  disabled = false,
+  size = 'md',
+  label,
+  helperText,
+  errorText,
+  emptyMessage = 'No matches',
+  allowCustomValue = false,
+  id,
+  name,
+  autoFocus,
+  style,
+  'aria-label': ariaLabel,
+}: ComboboxProps) {
+  const isControlled = controlledValue !== undefined;
+  const [internalValue, setInternalValue] = useState<string>(defaultValue);
+  const selected = isControlled ? controlledValue! : internalValue;
+
+  const selectedOption = options.find(o => o.value === selected);
+  const selectedLabel = selectedOption?.label ?? (allowCustomValue ? selected : '');
+
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [isFocused, setIsFocused] = useState(false);
+  const [isHovered, setIsHovered] = useState(false);
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const fieldRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const [dropdownPos, setDropdownPos] = useState({ top: 0, left: 0, width: 0 });
+
+  const reactId = useId();
+  const inputId = id ?? `lucent-combobox-${reactId}`;
+  const listboxId = `${inputId}-listbox`;
+
+  const hasError = Boolean(errorText);
+
+  // Filter options by query (case-insensitive, matches label or hint)
+  const filtered = open
+    ? options.filter(o => {
+        if (!query) return true;
+        const q = query.toLowerCase();
+        return (
+          o.label.toLowerCase().includes(q) ||
+          (o.hint?.toLowerCase().includes(q) ?? false)
+        );
+      })
+    : options;
+
+  // Keep activeIndex within filtered bounds
+  useEffect(() => {
+    if (activeIndex >= filtered.length) setActiveIndex(Math.max(0, filtered.length - 1));
+  }, [filtered.length, activeIndex]);
+
+  // Close on outside click
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (
+        !containerRef.current?.contains(e.target as Node) &&
+        !dropdownRef.current?.contains(e.target as Node)
+      ) {
+        closeAndRevert();
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, query, selected]);
+
+  // Position dropdown off the field wrapper (not the outer container — it includes helper/error text)
+  useLayoutEffect(() => {
+    if (!open || !fieldRef.current) return;
+    const rect = fieldRef.current.getBoundingClientRect();
+    setDropdownPos({ top: rect.bottom + 4, left: rect.left, width: rect.width });
+  }, [open, query]);
+
+  function commit(val: string) {
+    if (!isControlled) setInternalValue(val);
+    onChange?.(val);
+    setOpen(false);
+    setQuery('');
+  }
+
+  function closeAndRevert() {
+    if (allowCustomValue && query && query !== selectedLabel) {
+      commit(query);
+      return;
+    }
+    setOpen(false);
+    setQuery('');
+  }
+
+  function openAndSeedActive() {
+    if (disabled) return;
+    setOpen(true);
+    // Seed activeIndex to the currently-selected option if visible
+    const idx = options.findIndex(o => o.value === selected);
+    setActiveIndex(idx >= 0 ? idx : 0);
+  }
+
+  function handleKeyDown(e: KeyboardEvent<HTMLInputElement>) {
+    if (disabled) return;
+
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      closeAndRevert();
+      return;
+    }
+
+    if (!open) {
+      if (e.key === 'ArrowDown' || e.key === 'ArrowUp' || e.key === 'Enter') {
+        e.preventDefault();
+        openAndSeedActive();
+      }
+      return;
+    }
+
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      const enabled = filtered.map((o, i) => (o.disabled ? -1 : i)).filter(i => i >= 0);
+      if (enabled.length === 0) return;
+      const next = enabled.find(i => i > activeIndex) ?? enabled[0]!;
+      setActiveIndex(next);
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      const enabled = filtered.map((o, i) => (o.disabled ? -1 : i)).filter(i => i >= 0);
+      if (enabled.length === 0) return;
+      const prev = [...enabled].reverse().find(i => i < activeIndex) ?? enabled[enabled.length - 1]!;
+      setActiveIndex(prev);
+    } else if (e.key === 'Home') {
+      e.preventDefault();
+      setActiveIndex(0);
+    } else if (e.key === 'End') {
+      e.preventDefault();
+      setActiveIndex(filtered.length - 1);
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      const item = filtered[activeIndex];
+      if (item && !item.disabled) {
+        commit(item.value);
+      } else if (allowCustomValue && query) {
+        commit(query);
+      }
+    } else if (e.key === 'Tab') {
+      // Tab commits the highlighted match (if any) and lets focus move on
+      const item = filtered[activeIndex];
+      if (item && !item.disabled && query) {
+        commit(item.value);
+      } else {
+        setOpen(false);
+        setQuery('');
+      }
+    }
+  }
+
+  const borderColor = disabled
+    ? 'transparent'
+    : hasError
+      ? 'var(--lucent-danger-default)'
+      : isFocused
+        ? 'var(--lucent-accent-border)'
+        : isHovered
+          ? 'var(--lucent-border-strong)'
+          : 'var(--lucent-border-default)';
+
+  const boxShadow = isFocused
+    ? `0 0 0 3px ${hasError ? 'var(--lucent-danger-subtle)' : 'var(--lucent-accent-subtle)'}`
+    : 'none';
+
+  // Display value: when open, show query; when closed, show selected label
+  const displayValue = open ? query : selectedLabel;
+
+  return (
+    <div
+      ref={containerRef}
+      style={{ display: 'flex', flexDirection: 'column', gap: 'var(--lucent-space-1)', width: '100%', ...style }}
+    >
+      {label && (
+        <label
+          htmlFor={inputId}
+          style={{
+            fontSize: sizeLabelFont[size],
+            fontWeight: 'var(--lucent-font-weight-medium)',
+            color: disabled ? 'var(--lucent-text-disabled)' : 'var(--lucent-text-primary)',
+            fontFamily: 'var(--lucent-font-family-base)',
+          }}
+        >
+          {label}
+        </label>
+      )}
+
+      {/* Field wrapper — mirrors Input chrome */}
+      <div
+        ref={fieldRef}
+        style={{
+          position: 'relative',
+          display: 'flex',
+          alignItems: 'center',
+          height: sizeH[size],
+          border: `1px solid ${borderColor}`,
+          borderRadius: 'var(--lucent-radius-lg)',
+          boxShadow,
+          background: disabled ? 'color-mix(in srgb, var(--lucent-text-primary) 6%, transparent)' : 'var(--lucent-surface)',
+          overflow: 'hidden',
+          cursor: disabled ? 'not-allowed' : 'text',
+          transition: [
+            `border-color var(--lucent-duration-fast) var(--lucent-easing-default)`,
+            `box-shadow var(--lucent-duration-fast) var(--lucent-easing-default)`,
+          ].join(', '),
+        }}
+        onMouseEnter={() => { if (!disabled) setIsHovered(true); }}
+        onMouseLeave={() => setIsHovered(false)}
+        onClick={() => {
+          if (disabled) return;
+          if (!open) openAndSeedActive();
+          inputRef.current?.focus();
+        }}
+      >
+        <input
+          ref={inputRef}
+          id={inputId}
+          name={name}
+          type="text"
+          role="combobox"
+          autoComplete="off"
+          autoCorrect="off"
+          spellCheck={false}
+          autoFocus={autoFocus}
+          disabled={disabled}
+          placeholder={placeholder}
+          value={displayValue}
+          aria-autocomplete="list"
+          aria-expanded={open}
+          aria-controls={open ? listboxId : undefined}
+          aria-activedescendant={
+            open && filtered[activeIndex]
+              ? `${inputId}-option-${filtered[activeIndex]!.value}`
+              : undefined
+          }
+          aria-label={ariaLabel}
+          aria-invalid={hasError}
+          aria-describedby={
+            hasError ? `${inputId}-error` : helperText ? `${inputId}-helper` : undefined
+          }
+          onChange={e => {
+            setQuery(e.target.value);
+            setOpen(true);
+            setActiveIndex(0);
+          }}
+          onKeyDown={handleKeyDown}
+          onFocus={() => {
+            setIsFocused(true);
+            if (!open) openAndSeedActive();
+          }}
+          onBlur={() => {
+            setIsFocused(false);
+          }}
+          style={{
+            width: '100%',
+            height: '100%',
+            paddingLeft: sizePx[size],
+            paddingRight: `calc(${sizePx[size]} + 14px + var(--lucent-space-1))`,
+            fontSize: sizeFont[size],
+            fontFamily: 'var(--lucent-font-family-base)',
+            color: disabled ? 'var(--lucent-text-disabled)' : 'var(--lucent-text-primary)',
+            background: 'transparent',
+            border: 'none',
+            outline: 'none',
+            cursor: disabled ? 'not-allowed' : 'text',
+            boxSizing: 'border-box',
+          }}
+        />
+
+        {/* Chevron */}
+        <span
+          aria-hidden
+          style={{
+            position: 'absolute',
+            right: sizePx[size],
+            pointerEvents: 'none',
+            color: disabled ? 'var(--lucent-text-disabled)' : 'var(--lucent-text-secondary)',
+            display: 'flex',
+            alignItems: 'center',
+            transform: open ? 'rotate(180deg)' : 'rotate(0deg)',
+            transition: 'transform var(--lucent-duration-fast) var(--lucent-easing-default)',
+          }}
+        >
+          <svg width={14} height={14} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
+            <polyline points="6 9 12 15 18 9" />
+          </svg>
+        </span>
+      </div>
+
+      {/* Dropdown — portaled to escape overflow:hidden ancestors */}
+      {open && !disabled && createPortal(
+        <div
+          ref={dropdownRef}
+          id={listboxId}
+          role="listbox"
+          style={{
+            position: 'fixed',
+            top: dropdownPos.top,
+            left: dropdownPos.left,
+            width: dropdownPos.width,
+            zIndex: 1000,
+            background: 'color-mix(in srgb, var(--lucent-surface-overlay) 85%, transparent)',
+            backdropFilter: 'blur(6px)',
+            WebkitBackdropFilter: 'blur(6px)',
+            border: '1px solid color-mix(in srgb, var(--lucent-accent-default) 15%, var(--lucent-border-default))',
+            borderRadius: 'var(--lucent-radius-lg)',
+            boxShadow: '0 0 24px -4px color-mix(in srgb, var(--lucent-accent-default) 12%, transparent), var(--lucent-shadow-md)',
+            maxHeight: 260,
+            overflowY: 'auto',
+            padding: dropdownPadding[size],
+            fontFamily: 'var(--lucent-font-family-base)',
+          }}
+        >
+          {filtered.length === 0 ? (
+            <div
+              style={{
+                padding: dropdownPadding[size],
+                fontSize: sizeFont[size],
+                color: 'var(--lucent-text-secondary)',
+              }}
+            >
+              {emptyMessage}
+            </div>
+          ) : (
+            filtered.map((opt, i) => {
+              const isActive = i === activeIndex;
+              const isSelected = opt.value === selected;
+              const isDisabled = opt.disabled ?? false;
+              const prevGroup = i > 0 ? filtered[i - 1]!.group : undefined;
+              const showGroupHeader = opt.group && opt.group !== prevGroup;
+
+              return (
+                <div key={opt.value}>
+                  {showGroupHeader && (
+                    <div
+                      role="presentation"
+                      style={{
+                        padding: `var(--lucent-space-2) ${dropdownPadding[size]} var(--lucent-space-1)`,
+                        fontSize: 'var(--lucent-font-size-xs)',
+                        fontWeight: 'var(--lucent-font-weight-semibold)',
+                        color: 'var(--lucent-text-secondary)',
+                        textTransform: 'uppercase',
+                        letterSpacing: '0.04em',
+                      }}
+                    >
+                      {opt.group}
+                    </div>
+                  )}
+                  <div
+                    id={`${inputId}-option-${opt.value}`}
+                    role="option"
+                    aria-selected={isSelected}
+                    aria-disabled={isDisabled}
+                    onMouseDown={e => {
+                      // Prevent input blur before we commit
+                      e.preventDefault();
+                    }}
+                    onClick={() => {
+                      if (!isDisabled) commit(opt.value);
+                    }}
+                    onMouseEnter={() => setActiveIndex(i)}
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'space-between',
+                      gap: 'var(--lucent-space-2)',
+                      padding: dropdownPadding[size],
+                      borderRadius: 'var(--lucent-radius-md)',
+                      cursor: isDisabled ? 'not-allowed' : 'pointer',
+                      background: isActive && !isDisabled
+                        ? 'color-mix(in srgb, var(--lucent-text-primary) 5%, transparent)'
+                        : 'transparent',
+                      opacity: isDisabled ? 0.5 : 1,
+                      fontSize: sizeFont[size],
+                      color: isSelected ? 'var(--lucent-accent-default)' : 'var(--lucent-text-primary)',
+                      fontWeight: isSelected
+                        ? 'var(--lucent-font-weight-medium)'
+                        : 'var(--lucent-font-weight-regular)',
+                    }}
+                  >
+                    <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                      {opt.label}
+                    </span>
+                    {opt.hint && (
+                      <span
+                        style={{
+                          fontSize: hintFont[size],
+                          color: 'var(--lucent-text-secondary)',
+                          flexShrink: 0,
+                        }}
+                      >
+                        {opt.hint}
+                      </span>
+                    )}
+                  </div>
+                </div>
+              );
+            })
+          )}
+        </div>,
+        document.body,
+      )}
+
+      {hasError && (
+        <span
+          id={`${inputId}-error`}
+          role="alert"
+          style={{
+            fontSize: sizeLabelFont[size],
+            color: 'var(--lucent-danger-text)',
+            fontFamily: 'var(--lucent-font-family-base)',
+          }}
+        >
+          {errorText}
+        </span>
+      )}
+      {!hasError && helperText && (
+        <span
+          id={`${inputId}-helper`}
+          style={{
+            fontSize: sizeLabelFont[size],
+            color: 'var(--lucent-text-secondary)',
+            fontFamily: 'var(--lucent-font-family-base)',
+          }}
+        >
+          {helperText}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/components/atoms/Combobox/Combobox.tsx
+++ b/src/components/atoms/Combobox/Combobox.tsx
@@ -381,6 +381,7 @@ export function Combobox({
             top: dropdownPos.top,
             left: dropdownPos.left,
             width: dropdownPos.width,
+            boxSizing: 'border-box',
             zIndex: 1000,
             background: 'color-mix(in srgb, var(--lucent-surface-overlay) 85%, transparent)',
             backdropFilter: 'blur(6px)',

--- a/src/components/atoms/Combobox/index.ts
+++ b/src/components/atoms/Combobox/index.ts
@@ -1,0 +1,3 @@
+export { Combobox } from './Combobox.js';
+export type { ComboboxProps, ComboboxSize, ComboboxOption } from './Combobox.js';
+export { COMPONENT_MANIFEST as ComboboxManifest } from './Combobox.manifest.js';

--- a/src/components/atoms/index.ts
+++ b/src/components/atoms/index.ts
@@ -10,6 +10,7 @@ export * from './Checkbox/index.js';
 export * from './Radio/index.js';
 export * from './Toggle/index.js';
 export * from './Select/index.js';
+export * from './Combobox/index.js';
 export * from './Tag/index.js';
 export * from './Tooltip/index.js';
 export * from './Icon/index.js';


### PR DESCRIPTION
Closes #158.

## Summary
- New **Combobox** atom: searchable single-select form field that fills the gap between `Select` (native dropdown, no search — unusable past ~15 options) and `FilterSelect` (filter-bar pill chrome, wrong for forms).
- Input-matching chrome so it drops into `FormField` cleanly alongside other form controls.
- Full WAI-ARIA 1.2 combobox pattern: `role=combobox` + `aria-autocomplete=list`, `aria-expanded`, `aria-controls`, `aria-activedescendant`.

## API highlights
- `options: ComboboxOption[]` — supports secondary `hint` (e.g. `"UTC-05:00"`) and optional `group` headings
- Controlled (`value`) + uncontrolled (`defaultValue`) modes
- `allowCustomValue` escape hatch for free-form text with suggestions (tag input style)
- `label` / `helperText` / `errorText` built in, matching Input/Select
- `sm` / `md` / `lg` sizes — heights match Input at every tier
- Portal-rendered listbox positioned off the field wrapper so it sits flush under the field even when helper/error text is present

## Keyboard
- Type — filters options
- `ArrowDown` / `ArrowUp` — navigate enabled options (skips disabled)
- `Home` / `End` — first / last
- `Enter` — commit highlighted option (or raw query when `allowCustomValue`)
- `Tab` — commit match if query present, then move focus
- `Escape` — close without committing

## Registration
- `src/components/atoms/Combobox/{Combobox.tsx, Combobox.manifest.ts, index.ts}`
- Added to `src/components/atoms/index.ts` barrel
- Added to MCP registry at `server/registry.ts`
- `dev/ComponentPreview.tsx` — new Combobox section with timezone / grouped / sizes / helper / error / free-form / disabled demos

## Test plan
- [x] `pnpm exec tsc --noEmit` passes
- [x] `pnpm build` succeeds
- [x] `pnpm test` — 268/268 pass
- [ ] Verify dropdown positions directly under the field in all sizes, with and without helper/error text
- [ ] Verify keyboard nav (Arrow/Home/End/Enter/Tab/Escape) works as documented
- [ ] Verify grouped options render headings only once per group
- [ ] Verify `allowCustomValue` commits the typed query on Enter when no match

🤖 Generated with [Claude Code](https://claude.com/claude-code)