### PR TITLE
chore: reconcile main with npm (bring in 0.42.0 / 0.43.0 work)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # lucent-ui
 
+## 0.43.0
+
+### Minor Changes
+
+- **DataTable — sticky columns and horizontal scroll**
+
+  DataTable columns now support a `sticky` boolean prop that pins them in place during horizontal scroll. All body cells use `whiteSpace: nowrap` to prevent line breaking, allowing the table to overflow and scroll horizontally instead. Sticky columns get opaque backgrounds, a subtle right box-shadow on the last pinned column, and cumulative left offsets measured via ResizeObserver. Supports multiple sticky columns with correct stacking.
+
 ## 0.42.0
 
 ### Minor Changes

--- a/dev/ComponentPreview.tsx
+++ b/dev/ComponentPreview.tsx
@@ -2665,6 +2665,30 @@ function Inner({
         <Row label="Empty state" tokens={tokens}>
           <DataTable columns={[{ key: 'name', header: 'Name' }]} rows={[]} style={{ width: 320 }} />
         </Row>
+        <Row label="Sticky column + horizontal scroll" tokens={tokens}>
+          <DataTable
+            style={{ maxWidth: 600 }}
+            pageSize={0}
+            columns={[
+              { key: 'name', header: 'Name', sticky: true, sortable: true, width: '140px' },
+              { key: 'position', header: 'Position', sortable: true },
+              { key: 'email', header: 'Email' },
+              { key: 'availability', header: 'Availability', render: (row: { availability: string }) => <Badge variant={row.availability === 'Available' ? 'success' : 'warning'}>{row.availability}</Badge> },
+              { key: 'skills', header: 'Skills' },
+              { key: 'location', header: 'Location' },
+              { key: 'experience', header: 'Experience' },
+              { key: 'salary', header: 'Salary Range', align: 'right' as const },
+            ]}
+            rows={[
+              { name: 'Priya Patel', position: 'ML Engineer', email: 'priya.patel@email.com', availability: 'Available', skills: 'Python, TensorFlow, PyTorch', location: 'Remote', experience: '6 years', salary: '$140k–$180k' },
+              { name: 'Sophie Zhang', position: 'Frontend Engineer', email: 'sophie.zhang@email.com', availability: 'Available', skills: 'React, TypeScript, CSS', location: 'New York, NY', experience: '4 years', salary: '$120k–$150k' },
+              { name: 'Mia Tanaka', position: 'React Developer', email: 'mia.tanaka@email.com', availability: 'Available', skills: 'React, JavaScript, Redux', location: 'Los Angeles, CA', experience: '5 years', salary: '$130k–$160k' },
+              { name: 'Isabella Gomez', position: 'Data Scientist', email: 'isabella.gomez@email.com', availability: 'Available', skills: 'Python, scikit-learn, Pandas', location: 'Miami, FL', experience: '3 years', salary: '$110k–$140k' },
+              { name: 'Aiden Walsh', position: 'Data Analyst', email: 'aiden.walsh@email.com', availability: 'Open to opportunities', skills: 'SQL, Python, Tableau', location: 'Remote', experience: '2 years', salary: '$90k–$110k' },
+              { name: 'Omar Hassan', position: 'Senior Backend', email: 'omar.hassan@email.com', availability: 'Available', skills: 'Python, FastAPI, PostgreSQL', location: 'Denver, CO', experience: '8 years', salary: '$160k–$200k' },
+            ]}
+          />
+        </Row>
       </Section>
 
       <Section title="CommandPalette" tokens={tokens} hidden={!showSection('CommandPalette')}>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lucent-ui",
-  "version": "0.42.0",
+  "version": "0.43.0",
   "description": "An AI-first React component library with machine-readable manifests.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lucent-ui",
-  "version": "0.41.0",
+  "version": "0.42.0",
   "description": "An AI-first React component library with machine-readable manifests.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/components/molecules/DataTable/DataTable.tsx
+++ b/src/components/molecules/DataTable/DataTable.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, type CSSProperties, type ReactNode } from 'react';
+import { useState, useEffect, useLayoutEffect, useRef, type CSSProperties, type ReactNode } from 'react';
 import { Text } from '../../atoms/Text/index.js';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -15,6 +15,8 @@ export interface DataTableColumn<T> {
   headerFilter?: ReactNode;
   width?: string;
   align?: 'left' | 'center' | 'right';
+  /** Pin this column so it stays visible when the table scrolls horizontally */
+  sticky?: boolean;
 }
 
 export interface DataTableProps<T extends object> {
@@ -92,6 +94,42 @@ export function DataTable<T extends object>({
   const currentPage = isPageControlled ? controlledPage! : internalPage;
 
   const hasFilterableColumns = columns.some(c => c.filterable);
+
+  // Sticky columns — measure header widths to compute cumulative left offsets
+  const stickyHeaderRefs = useRef<Map<string, HTMLTableCellElement>>(new Map());
+  const [stickyLefts, setStickyLefts] = useState<Record<string, number>>({});
+  const lastStickyKey = (() => {
+    for (let i = columns.length - 1; i >= 0; i--) {
+      const col = columns[i];
+      if (col?.sticky) return col.key;
+    }
+    return null;
+  })();
+
+  useLayoutEffect(() => {
+    const keys = columns.filter(c => c.sticky).map(c => c.key);
+    if (keys.length === 0) return;
+
+    const measure = () => {
+      const lefts: Record<string, number> = {};
+      let cumLeft = 0;
+      for (const key of keys) {
+        lefts[key] = cumLeft;
+        const el = stickyHeaderRefs.current.get(key);
+        if (el) cumLeft += el.getBoundingClientRect().width;
+      }
+      setStickyLefts(lefts);
+    };
+
+    measure();
+
+    const observer = new ResizeObserver(measure);
+    for (const key of keys) {
+      const el = stickyHeaderRefs.current.get(key);
+      if (el) observer.observe(el);
+    }
+    return () => observer.disconnect();
+  }, [columns]);
 
   // Filter (before sort)
   const filteredRows = hasFilterableColumns
@@ -190,7 +228,7 @@ export function DataTable<T extends object>({
         background: 'var(--lucent-surface)',
       }}>
         <table style={{
-          width: '100%',
+          minWidth: '100%',
           borderCollapse: 'collapse',
           fontFamily: 'var(--lucent-font-family-base)',
           fontSize: 'var(--lucent-font-size-sm)',
@@ -203,18 +241,32 @@ export function DataTable<T extends object>({
                 return (
                   <th
                     key={col.key}
+                    ref={col.sticky ? (el: HTMLTableCellElement | null) => {
+                      if (el) stickyHeaderRefs.current.set(col.key, el);
+                      else stickyHeaderRefs.current.delete(col.key);
+                    } : undefined}
                     onClick={col.sortable ? () => handleSort(col.key) : undefined}
                     style={{
                       padding: 'var(--lucent-space-3) var(--lucent-space-4)',
                       textAlign: col.align ?? 'left',
                       fontWeight: 'var(--lucent-font-weight-medium)',
                       color: 'var(--lucent-text-secondary)',
-                      background: 'color-mix(in srgb, var(--lucent-text-primary) 5%, transparent)',
+                      background: col.sticky
+                        ? 'color-mix(in srgb, var(--lucent-text-primary) 5%, var(--lucent-surface))'
+                        : 'color-mix(in srgb, var(--lucent-text-primary) 5%, transparent)',
                       borderBottom: '1px solid var(--lucent-border-default)',
                       cursor: col.sortable ? 'pointer' : 'default',
                       userSelect: 'none',
                       whiteSpace: 'nowrap',
                       ...(col.width ? { width: col.width } : {}),
+                      ...(col.sticky ? {
+                        position: 'sticky' as const,
+                        left: stickyLefts[col.key] ?? 0,
+                        zIndex: 2,
+                      } : {}),
+                      ...(col.key === lastStickyKey ? {
+                        boxShadow: '2px 0 4px -2px color-mix(in srgb, var(--lucent-text-primary) 10%, transparent)',
+                      } : {}),
                     }}
                   >
                     <span style={{ display: 'inline-flex', alignItems: 'center', gap: 'var(--lucent-space-1)' }}>
@@ -270,6 +322,19 @@ export function DataTable<T extends object>({
                         color: 'var(--lucent-text-primary)',
                         textAlign: col.align ?? 'left',
                         verticalAlign: 'middle',
+                        whiteSpace: 'nowrap',
+                        ...(col.sticky ? {
+                          position: 'sticky' as const,
+                          left: stickyLefts[col.key] ?? 0,
+                          zIndex: 1,
+                          background: hoveredRow === i
+                            ? 'color-mix(in srgb, var(--lucent-text-primary) 4%, var(--lucent-surface))'
+                            : 'var(--lucent-surface)',
+                          transition: 'background var(--lucent-duration-fast) var(--lucent-easing-default)',
+                        } : {}),
+                        ...(col.key === lastStickyKey ? {
+                          boxShadow: '2px 0 4px -2px color-mix(in srgb, var(--lucent-text-primary) 10%, transparent)',
+                        } : {}),
                       }}
                     >
                       {col.render


### PR DESCRIPTION
## Summary

`main` has drifted from npm — releases 0.42.0 and 0.43.0 were shipped from the `chore/release-0.41.0` branch without being merged back. This PR reconciles main so it matches npm's 0.43.0 state.

**What main was missing:**
- Version bump `0.41.0 → 0.42.0` in package.json
- DataTable sticky columns feature (the actual 0.43.0 code change — main would have regressed this if we released from it)
- Version bump `0.42.0 → 0.43.0` in package.json
- `## 0.43.0` entry in CHANGELOG.md

**Commits cherry-picked from `chore/release-0.41.0`:**
- `968c3b8` — chore: bump version to 0.42.0 (was `05c12f3`)
- `755794d` — feat: add sticky column support to DataTable (was `d8a27d6`)
- `edc21e0` — chore: bump version to 0.43.0 (was `b4b0249`)

The `1ae6582` tsconfig fix was skipped — it was already on main via a separate path.

## Rationale

This unblocks the 0.44.0 release (Combobox atom — #158). Without this PR, cutting 0.44.0 from main would publish a build missing DataTable sticky columns, regressing what users got in 0.43.0.

Going forward, releases should merge back to main so the two stay in sync.

## Test plan
- [x] `pnpm exec tsc --noEmit` passes
- [x] `pnpm test --run` — 268/268 pass
- [x] `package.json` version matches npm (0.43.0)
- [x] CHANGELOG has both 0.42.0 and 0.43.0 entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)